### PR TITLE
Help mode

### DIFF
--- a/engine/src/Graphics/Math.fs
+++ b/engine/src/Graphics/Math.fs
@@ -81,6 +81,24 @@ type Rect =
     member inline this.Shrink(x, y) = this.Expand(-x, -y)
     member inline this.Shrink amount = this.Shrink(amount, amount)
 
+    member inline this.SliceCenterX amount =
+        let center = this.CenterX
+        {
+            Left = center - amount * 0.5f
+            Top = this.Top
+            Right = center + amount * 0.5f
+            Bottom = this.Bottom
+        }
+
+    member inline this.SliceCenterY amount =
+        let center = this.CenterY
+        {
+            Left = this.Left
+            Top = center - amount * 0.5f
+            Right = this.Right
+            Bottom = center + amount * 0.5f
+        }
+
     member inline this.SliceLeft amount =
         {
             Left = this.Left

--- a/engine/src/Input/Input.fs
+++ b/engine/src/Input/Input.fs
@@ -432,6 +432,7 @@ module Input =
         this_frame_finished <- false
         update_input_listener ()
 
+    // todo: find out what this was used for / remove it because unused
     let button_pressed_recently () =
         (DateTime.UtcNow.Ticks - last_input_event) < 100L * 10_000L
 

--- a/engine/src/UI/Position.fs
+++ b/engine/src/UI/Position.fs
@@ -156,7 +156,7 @@ type Position with
     static member BorderBottomCorners amount =
         Position.Default.BorderBottomCorners amount
 
-    member this.CenterX width =
+    member this.CenterHorizontal width =
         let (lefto, lefta) = this.Left
         let (righto, righta) = this.Right
         let center = (0.5f * (lefto + righto), 0.5f * (lefta + righta))
@@ -165,7 +165,7 @@ type Position with
             Right = center ^+ (width * 0.5f)
         }
 
-    member this.CenterY height =
+    member this.CenterVertical height =
         let (topo, topa) = this.Top
         let (bottomo, bottoma) = this.Bottom
         let center = (0.5f * (topo + bottomo), 0.5f * (topa + bottoma))
@@ -174,10 +174,10 @@ type Position with
             Bottom = center ^+ (height * 0.5f)
         }
 
-    member this.Center (width, height) = this.CenterX(width).CenterY(height)
+    member this.Center (width, height) = this.CenterHorizontal(width).CenterVertical(height)
     
-    static member CenterX width = Position.Default.CenterX width
-    static member CenterY height = Position.Default.CenterY height
+    static member CenterHorizontal width = Position.Default.CenterHorizontal width
+    static member CenterVertical height = Position.Default.CenterVertical height
     static member Center (width, height) = Position.Default.Center (width, height)
 
     static member Row(y, height) =

--- a/interlude/src/Features/Import/Etterna/PackBrowser.fs
+++ b/interlude/src/Features/Import/Etterna/PackBrowser.fs
@@ -81,7 +81,7 @@ type EtternaPacksBrowserPage() =
     override this.Content() =
         begin_search filter
 
-        NavigationContainer.Column(Position = Position.CenterX(1400.0f).TrimTop(90.0f).TrimBottom(70.0f))
+        NavigationContainer.Column(Position = Position.CenterHorizontal(1400.0f).TrimTop(90.0f).TrimBottom(70.0f))
         |+ Dummy(NodeType.Leaf)
         |+ scroll_container
         |+ EmptyState(Icons.X, %"etterna_pack_browser.error")
@@ -97,7 +97,7 @@ type EtternaPacksBrowserPage() =
                 filter <- f
                 defer (fun () -> begin_search filter)
             ),
-            Position = Position.CenterX(1400.0f).SliceTop(60.0f).Translate(0.0f, 20.0f)
+            Position = Position.CenterHorizontal(1400.0f).SliceTop(60.0f).Translate(0.0f, 20.0f)
         )
         |+ LoadingIndicator.Border(fun () -> loading)
         :> Widget

--- a/interlude/src/Features/Import/osu!/Beatmaps/Beatmaps.fs
+++ b/interlude/src/Features/Import/osu!/Beatmaps/Beatmaps.fs
@@ -130,7 +130,7 @@ type BeatmapBrowserPage() =
         )
 
     let search_results =
-        NavigationContainer.Column(Position = Position.TrimTop(140.0f).CenterX(1400.0f).TrimBottom(70.0f))
+        NavigationContainer.Column(Position = Position.TrimTop(140.0f).CenterHorizontal(1400.0f).TrimBottom(70.0f))
         |+ Dummy(NodeType.Leaf)
         |+ scroll_container
         |>> Container
@@ -188,7 +188,7 @@ type BeatmapBrowserPage() =
                     Left = 0.72f %+ 0.0f
                 }
         )
-        |>> (fun nt -> Container(nt, Position = Position.Row(20.0f, 115.0f).CenterX(1400.0f)))
+        |>> (fun nt -> Container(nt, Position = Position.Row(20.0f, 115.0f).CenterHorizontal(1400.0f)))
         |+ (SearchBox(
                 Setting.simple "",
                 (fun (f: Filter) ->

--- a/interlude/src/Features/Online/Players/Profile/Profile.fs
+++ b/interlude/src/Features/Online/Players/Profile/Profile.fs
@@ -153,7 +153,7 @@ type private Profile() =
                             Colors.text_pink_2
                         else
                             Colors.text_red_2),
-                Position = Position.TrimRight(40.0f).SliceTop(70.0f).SliceRight(300.0f)
+                Position = Position.TrimRight(40.0f).SliceTop(InlaidButton.HEIGHT).SliceRight(300.0f)
             )
         )
         |+ Conditional(
@@ -163,7 +163,7 @@ type private Profile() =
                 add_friend,
                 Icons.USER_PLUS,
                 UnfocusedColor = Colors.text_green_2,
-                Position = Position.TrimRight(40.0f).SliceTop(70.0f).SliceRight(300.0f)
+                Position = Position.TrimRight(40.0f).SliceTop(InlaidButton.HEIGHT).SliceRight(300.0f)
             )
         )
         // Color button on your profile
@@ -173,7 +173,7 @@ type private Profile() =
                 %"online.players.profile.change_color",
                 change_color_dropdown,
                 Icons.REFRESH_CCW,
-                Position = Position.TrimRight(40.0f).SliceTop(70.0f).SliceRight(300.0f)
+                Position = Position.TrimRight(40.0f).SliceTop(InlaidButton.HEIGHT).SliceRight(300.0f)
             )
         )
         |+ color_picker
@@ -184,7 +184,7 @@ type private Profile() =
                 %"online.players.profile.invite_to_lobby",
                 (fun () -> Network.lobby.Value.InvitePlayer(data.Username)),
                 Icons.SEND,
-                Position = Position.TrimRight(380.0f).SliceTop(70.0f).SliceRight(300.0f)
+                Position = Position.TrimRight(380.0f).SliceTop(InlaidButton.HEIGHT).SliceRight(300.0f)
             )
         )
         :> Widget

--- a/interlude/src/Features/Options/Layout.fs
+++ b/interlude/src/Features/Options/Layout.fs
@@ -171,7 +171,7 @@ type private OptionsMenuFooter() as this =
             %"menu.back",
             Menu.Back,
             Icons.ARROW_LEFT_CIRCLE,
-            Position = Position.Box(0.0f, 1.0f, 10.0f, -HEIGHT + 7.5f, 180.0f, HEIGHT)
+            Position = Position.Box(0.0f, 1.0f, 10.0f, -HEIGHT + 7.5f, 180.0f, InlaidButton.HEIGHT)
         )
         |+ (
             FlowContainer.RightToLeft(300.0f, Spacing = 20.0f, Position = Position.SliceBottom(HEIGHT + 10.0f).Translate(-30.0f, -20.0f))

--- a/interlude/src/Features/Options/Layout.fs
+++ b/interlude/src/Features/Options/Layout.fs
@@ -40,7 +40,7 @@ type private OptionsMenuHeader(current_tab: Setting<OptionsMenuTab>) as this =
         { Position.Default with Left = pc %+ offset; Right = (1.0f - pc) %- offset }
 
     let tab_buttons =
-        DynamicFlowContainer.LeftToRight(Spacing = 10.0f, Position = scaled_margins.CenterY(60.0f))
+        DynamicFlowContainer.LeftToRight(Spacing = 10.0f, Position = scaled_margins.CenterVertical(60.0f))
         |+ OptionsMenuButton(
             Icons.HOME,
             60.0f,
@@ -81,7 +81,7 @@ type private OptionsMenuHeader(current_tab: Setting<OptionsMenuTab>) as this =
                     else
                         current_tab.Set (OptionsMenuTab.SearchResults <| SearchResults.get query)
                 ),
-                Position = { scaled_margins with Left = fst scaled_margins.Left * 2.0f, snd scaled_margins.Left * 2.0f }.CenterY(60.0f).TrimLeft(900.0f).Margin(Style.PADDING, 0.0f),
+                Position = { scaled_margins with Left = fst scaled_margins.Left * 2.0f, snd scaled_margins.Left * 2.0f }.CenterVertical(60.0f).TrimLeft(900.0f).Margin(Style.PADDING, 0.0f),
                 Fill = K Colors.cyan.O3,
                 Border = K Colors.cyan_accent,
                 TextColor = K Colors.text_cyan) with

--- a/interlude/src/Features/Options/OptionsMenu.fs
+++ b/interlude/src/Features/Options/OptionsMenu.fs
@@ -136,7 +136,7 @@ type OptionsMenuPage() =
             Position = { Position.Default with Right = 0.65f %- 60.0f }
         )
         |+ EmptyState(Icons.SETTINGS, %"menu.options", Subtitle = "Suggest in Discord what should go here")
-        |+ Callout.frame help_mode_info (fun (w, h) -> Position.CenterX(w).SliceBottom(h).Translate(0.0f, -65.0f))
+        |+ Callout.frame help_mode_info (fun (w, h) -> Position.CenterHorizontal(w).SliceBottom(h).Translate(0.0f, -65.0f))
         
     let options_home_page =
         NavigationContainer.Row(WrapNavigation = false, Position = Position.Margin(PRETTY_MARGIN_X, PRETTY_MARGIN_Y))

--- a/interlude/src/Features/Options/Search/Core.fs
+++ b/interlude/src/Features/Options/Search/Core.fs
@@ -43,7 +43,7 @@ module Search =
                         .Title(%"options.search.no_results.title")
                         .Body(%"options.search.no_results.body")
                 )
-                (fun (w, h) -> Position.Margin(PRETTY_MARGIN_X, PRETTY_MARGIN_Y * 2.0f).SliceBottom(h).CenterX(w))
+                (fun (w, h) -> Position.Margin(PRETTY_MARGIN_X, PRETTY_MARGIN_Y * 2.0f).SliceBottom(h).CenterHorizontal(w))
             :> Widget
         else
             let content = 

--- a/interlude/src/Features/Score/BottomBanner.fs
+++ b/interlude/src/Features/Score/BottomBanner.fs
@@ -100,7 +100,7 @@ type BottomBanner(stats: ScoreScreenStats ref, score_info: ScoreInfo, graph: Sco
             Align = Alignment.CENTER
         )
         |* (
-            GridFlowContainer<Widget>(65.0f, 4, Spacing = (30.0f, 0.0f), Position = { Position.SliceBottom(65.0f) with Left = 0.35f %+ 30.0f; Right = 1.0f %- 20.0f }.Translate(0.0f, 5.0f))
+            GridFlowContainer<Widget>(InlaidButton.HEIGHT, 4, Spacing = (30.0f, 0.0f), Position = { Position.SliceBottom(InlaidButton.HEIGHT) with Left = 0.35f %+ 30.0f; Right = 1.0f %- 20.0f }.Translate(0.0f, 5.0f))
             |+ InlaidButton(
                 %"score.graph.settings",
                 (fun () ->

--- a/interlude/src/Features/Skins/EditHUD/EditScreen.fs
+++ b/interlude/src/Features/Skins/EditHUD/EditScreen.fs
@@ -588,16 +588,16 @@ type PositionerInfo(ctx: PositionerContext) =
 
     let mutable currently_on_right = true
 
-    let LEFT_POSITION : Position = Position.CenterY(400.0f).SliceLeft(375.0f)
-    let RIGHT_POSITION : Position = Position.CenterY(400.0f).SliceRight(375.0f)
+    let LEFT_POSITION : Position = Position.CenterVertical(400.0f).SliceLeft(375.0f)
+    let RIGHT_POSITION : Position = Position.CenterVertical(400.0f).SliceRight(375.0f)
 
     let dropdown_wrapper = 
         DropdownWrapper(
             (fun d ->
                 if currently_on_right then 
-                    Position.CenterY(d.Height).BorderLeft(370.0f).Translate(-10.0f, 0.0f)
+                    Position.CenterVertical(d.Height).BorderLeft(370.0f).Translate(-10.0f, 0.0f)
                 else
-                    Position.CenterY(d.Height).BorderRight(370.0f).Translate(10.0f, 0.0f)
+                    Position.CenterVertical(d.Height).BorderRight(370.0f).Translate(10.0f, 0.0f)
             ), 
             FocusTrap = true
         )

--- a/interlude/src/Features/Skins/Select.fs
+++ b/interlude/src/Features/Skins/Select.fs
@@ -227,7 +227,7 @@ type SelectSkinsPage() =
             c
 
         let action_buttons =
-            GridFlowContainer<Widget>(70.0f, 4, Spacing = (0.0f, 0.0f), Position = Position.SliceTop(60.0f), WrapNavigation = false)
+            GridFlowContainer<Widget>(InlaidButton.HEIGHT, 4, Spacing = (0.0f, 0.0f), Position = Position.SliceTop(InlaidButton.HEIGHT), WrapNavigation = false)
             |+ InlaidButton(
                 %"skins.edit",
                 (fun () ->

--- a/interlude/src/Features/Toolbar/Toolbar.fs
+++ b/interlude/src/Features/Toolbar/Toolbar.fs
@@ -45,7 +45,7 @@ type Toolbar() =
                 Imports.import_in_progress,
                 Position = Position.BorderBottom(Style.PADDING)
             )
-        container.Tooltip(Help.Info("menu.import", "import"))
+        container.Tooltip(Help.text_hotkey(%"menu.import.tooltip", "import"))
 
     override this.Init(parent) =
         container
@@ -76,7 +76,7 @@ type Toolbar() =
                 (fun () -> OptionsMenuPage().Show()),
                 Icons.SETTINGS
             )
-                .Tooltip(Help.Info("menu.options", "options"))
+                .Tooltip(Help.text_hotkey(%"menu.options.tooltip", "options"))
             |+ import_button
             |+ InlaidButton(
                 %"menu.wiki",
@@ -85,7 +85,7 @@ type Toolbar() =
                 HoverIcon = Icons.BOOK_OPEN,
                 Hotkey = "wiki"
             )
-                .Tooltip(Help.Info("menu.wiki", "wiki"))
+                .Tooltip(Help.text_hotkey(%"menu.wiki.tooltip", "wiki"))
             |+ InlaidButton(
                 %"menu.stats",
                 (fun () ->
@@ -94,7 +94,7 @@ type Toolbar() =
                 ),
                 Icons.TRENDING_UP
             )
-                .Tooltip(Help.Info("menu.stats")))
+                .Tooltip(Help.text(%"menu.stats.tooltip")))
         |+ NetworkStatus(Position = Position.SliceTop(HEIGHT).SliceRight(300.0f))
         |+ HotkeyAction(
             "edit_noteskin",

--- a/interlude/src/Features/Toolbar/Toolbar.fs
+++ b/interlude/src/Features/Toolbar/Toolbar.fs
@@ -34,7 +34,6 @@ type Toolbar() =
         | None -> ()
 
     let import_button =
-        let dropdown_wrapper = DropdownWrapper(fun d -> Position.SliceTop(d.Height).Translate(0.0f, HEIGHT).SliceLeft(370.0f))
         let container = 
             InlaidButton(
                 %"menu.import",
@@ -44,9 +43,9 @@ type Toolbar() =
             )
             |+ LoadingIndicator.Strip(
                 Imports.import_in_progress,
-                Position = Position.SliceBottom(15.0f).SliceTop(Style.PADDING)
+                Position = Position.BorderBottom(Style.PADDING)
             )
-        container.Help(Help.Info("menu.import").Hotkey("import"))
+        container.Tooltip(Help.Info("menu.import", "import"))
 
     override this.Init(parent) =
         container
@@ -64,20 +63,20 @@ type Toolbar() =
             %"menu.back",
             (fun () -> Screen.back Transitions.UnderLogo |> ignore),
             Icons.ARROW_LEFT_CIRCLE,
-            Position = Position.Box(0.0f, 1.0f, 10.0f, -HEIGHT + 7.5f, 180.0f, HEIGHT)
+            Position = Position.Box(0.0f, 1.0f, 10.0f, -HEIGHT + 7.5f, 180.0f, InlaidButton.HEIGHT)
         )
         |+ (FlowContainer.LeftToRight(
                 180.0f,
                 Spacing = 10.0f,
                 AllowNavigation = false,
-                Position = Position.SliceTop(HEIGHT).TrimLeft(20.0f)
+                Position = Position.SliceTop(InlaidButton.HEIGHT).TrimLeft(20.0f)
             )
             |+ InlaidButton(
                 %"menu.options",
                 (fun () -> OptionsMenuPage().Show()),
                 Icons.SETTINGS
             )
-                .Help(Help.Info("menu.options").Hotkey("options"))
+                .Tooltip(Help.Info("menu.options", "options"))
             |+ import_button
             |+ InlaidButton(
                 %"menu.wiki",
@@ -86,7 +85,7 @@ type Toolbar() =
                 HoverIcon = Icons.BOOK_OPEN,
                 Hotkey = "wiki"
             )
-                .Help(Help.Info("menu.wiki").Hotkey("wiki"))
+                .Tooltip(Help.Info("menu.wiki", "wiki"))
             |+ InlaidButton(
                 %"menu.stats",
                 (fun () ->
@@ -95,7 +94,7 @@ type Toolbar() =
                 ),
                 Icons.TRENDING_UP
             )
-                .Help(Help.Info("menu.stats")))
+                .Tooltip(Help.Info("menu.stats")))
         |+ NetworkStatus(Position = Position.SliceTop(HEIGHT).SliceRight(300.0f))
         |+ HotkeyAction(
             "edit_noteskin",

--- a/interlude/src/Features/Wiki/Wiki.fs
+++ b/interlude/src/Features/Wiki/Wiki.fs
@@ -21,7 +21,7 @@ type WikiBrowserPage() =
 
     let buttons =
         NavigationContainer.Row(
-            Position = Position.SliceTop(70.0f).CenterX(1400.0f).Margin(0.0f, 10.0f)
+            Position = Position.SliceTop(70.0f).CenterHorizontal(1400.0f).Margin(0.0f, 10.0f)
         )
         |+ Button(
             fun () ->
@@ -120,7 +120,7 @@ type WikiBrowserPage() =
         | None -> content.Add(LoadingState())
 
         content._Size <- y - PARAGRAPH_SPACING + Style.PADDING * 2.0f
-        let scroll_container = ScrollContainer(content, Margin = Style.PADDING, Position = Position.CenterX(PAGE_WIDTH).Margin(-Style.PADDING, 80.0f))
+        let scroll_container = ScrollContainer(content, Margin = Style.PADDING, Position = Position.CenterHorizontal(PAGE_WIDTH).Margin(-Style.PADDING, 80.0f))
         Heading.scroll_handler <- fun w -> scroll_container.Scroll(w.Bounds.Top - scroll_container.Bounds.Top)
         container.Current <- scroll_container
 

--- a/interlude/src/UI/Animations.fs
+++ b/interlude/src/UI/Animations.fs
@@ -284,3 +284,74 @@ module StripeWipe =
                 (left, bounds.Bottom)
             )
             color.AsQuad
+
+module LoadingAnimation =
+
+    let private draw_border_piece (bounds: Rect) (a: float32) (length: float32) (color: Color) =
+        let perimeter = (bounds.Width + bounds.Height) * 2.0f
+        let a = a % 1.0f
+        let b = a + length
+
+        let corner_1 = bounds.Width / perimeter
+        let corner_2 = (bounds.Width + bounds.Height) / perimeter
+        let corner_3 = corner_1 + corner_2
+
+        if b > 1.0f || a < corner_1 then
+            Draw.rect
+                (Rect.Create(
+                    (if b > 1.0f then
+                            bounds.Left
+                        else
+                            bounds.Left + a * perimeter),
+                    bounds.Top,
+                    bounds.Left + (b % 1.0f) * perimeter |> min bounds.Right,
+                    bounds.Top + Style.PADDING
+                ))
+                color
+
+        if b > corner_1 && a < corner_2 then
+            Draw.rect
+                (Rect.Create(
+                    bounds.Right - Style.PADDING,
+                    bounds.Top + (a - corner_1) * perimeter |> max bounds.Top,
+                    bounds.Right,
+                    bounds.Top + (b - corner_1) * perimeter |> min bounds.Bottom
+                ))
+                color
+
+        if b > corner_2 && a < corner_3 then
+            Draw.rect
+                (Rect.Create(
+                    bounds.Right - (a - corner_2) * perimeter |> min bounds.Right,
+                    bounds.Bottom - Style.PADDING,
+                    bounds.Right - (b - corner_2) * perimeter |> max bounds.Left,
+                    bounds.Bottom
+                ))
+                color
+
+        if b > corner_3 && a < 1.0f then
+            Draw.rect
+                (Rect.Create(
+                    bounds.Left,
+                    bounds.Bottom - (a - corner_3) * perimeter |> min bounds.Bottom,
+                    bounds.Left + Style.PADDING,
+                    bounds.Bottom - (b - corner_3) * perimeter |> max bounds.Top
+                ))
+                color
+
+    let draw_border (bounds: Rect) (a: float32) (color: Color) =
+        draw_border_piece bounds a 0.1f color
+        draw_border_piece bounds (a + 0.333f) 0.1f color
+        draw_border_piece bounds (a + 0.666f) 0.1f color
+    
+    let draw_border_more (bounds: Rect) (a: float32) (color: Color) =
+        draw_border_piece bounds a 0.04f color
+        draw_border_piece bounds (a + 0.1f) 0.04f color
+        draw_border_piece bounds (a + 0.2f) 0.04f color
+        draw_border_piece bounds (a + 0.3f) 0.04f color
+        draw_border_piece bounds (a + 0.4f) 0.04f color
+        draw_border_piece bounds (a + 0.5f) 0.04f color
+        draw_border_piece bounds (a + 0.6f) 0.04f color
+        draw_border_piece bounds (a + 0.7f) 0.04f color
+        draw_border_piece bounds (a + 0.8f) 0.04f color
+        draw_border_piece bounds (a + 0.9f) 0.04f color

--- a/interlude/src/UI/Buttons.fs
+++ b/interlude/src/UI/Buttons.fs
@@ -78,6 +78,8 @@ type InlaidButton(label_func: unit -> string, on_click: unit -> unit, icon: stri
             )
         )
 
+    static member HEIGHT = 55.0f
+
     new (label: string, on_click: unit -> unit, icon: string) = InlaidButton(K label, on_click, icon)
 
     member val Hotkey : Hotkey = "none" with get, set
@@ -86,7 +88,8 @@ type InlaidButton(label_func: unit -> string, on_click: unit -> unit, icon: stri
     member val UnfocusedColor = Colors.text_greyout with get, set
 
     override this.Init(parent) =
-        this |+ Clickable.Focus this
+        this 
+        |+ Clickable.Focus this
         |* HotkeyAction(
             this.Hotkey,
             fun () ->
@@ -101,20 +104,18 @@ type InlaidButton(label_func: unit -> string, on_click: unit -> unit, icon: stri
         Style.hover.Play()
 
     override this.Draw() =
-        let area = this.Bounds.TrimBottom(15.0f)
-
         let text =
             if this.Focused then
                 sprintf "%s %s" this.HoverIcon this.HoverText
             else
                 sprintf "%s %s" icon (label_func())
 
-        Draw.rect area (Colors.shadow_1.O2)
+        Draw.rect this.Bounds (Colors.shadow_1.O2)
 
         Text.fill_b (
             Style.font,
             text,
-            area.Shrink(10.0f, 5.0f),
+            this.Bounds.Shrink(10.0f, 5.0f),
             (if this.Focused then
                  Colors.text_yellow_2
              else

--- a/interlude/src/UI/Help.fs
+++ b/interlude/src/UI/Help.fs
@@ -246,8 +246,15 @@ type Tooltip(content: Callout) =
         Draw.rect bounds Colors.shadow_2.O3
         Callout.draw (bounds.Left, bounds.Top, width, height, Colors.text, content)
 
-[<AutoOpen>]
 module Help =
+    let text (text: string) = Callout.Normal.Body(text)
+    let hotkey (hk: Hotkey) = Callout.Normal.Hotkey(hk)
+    let text_hotkey (text: string, hk: Hotkey) = Callout.Normal.Body(text).Hotkey(hk)
+    let info (title: string, body: string) = Callout.Normal.Title(title).Body(body)
+    let info_hotkey (title: string, body: string, hk: Hotkey) = Callout.Normal.Title(title).Body(body).Hotkey(hk)
+
+[<AutoOpen>]
+module HelpExtensions =
 
     type Container with
         member this.Help(content: Callout) = this |+ Help content

--- a/interlude/src/UI/Loaders.fs
+++ b/interlude/src/UI/Loaders.fs
@@ -45,59 +45,6 @@ module LoadingIndicator =
         let animation = Animation.Counter(1500.0)
         let fade = Animation.Fade 0.0f
 
-        // todo: move to Animations.fs
-        let draw (bounds: Rect) (a: float32) (length: float32) (color: Color) =
-            let perimeter = (bounds.Width + bounds.Height) * 2.0f
-            let a = a % 1.0f
-            let b = a + length
-
-            let corner_1 = bounds.Width / perimeter
-            let corner_2 = (bounds.Width + bounds.Height) / perimeter
-            let corner_3 = corner_1 + corner_2
-
-            if b > 1.0f || a < corner_1 then
-                Draw.rect
-                    (Rect.Create(
-                        (if b > 1.0f then
-                             bounds.Left
-                         else
-                             bounds.Left + a * perimeter),
-                        bounds.Top,
-                        bounds.Left + (b % 1.0f) * perimeter |> min bounds.Right,
-                        bounds.Top + Style.PADDING
-                    ))
-                    color
-
-            if b > corner_1 && a < corner_2 then
-                Draw.rect
-                    (Rect.Create(
-                        bounds.Right - Style.PADDING,
-                        bounds.Top + (a - corner_1) * perimeter |> max bounds.Top,
-                        bounds.Right,
-                        bounds.Top + (b - corner_1) * perimeter |> min bounds.Bottom
-                    ))
-                    color
-
-            if b > corner_2 && a < corner_3 then
-                Draw.rect
-                    (Rect.Create(
-                        bounds.Right - (a - corner_2) * perimeter |> min bounds.Right,
-                        bounds.Bottom - Style.PADDING,
-                        bounds.Right - (b - corner_2) * perimeter |> max bounds.Left,
-                        bounds.Bottom
-                    ))
-                    color
-
-            if b > corner_3 && a < 1.0f then
-                Draw.rect
-                    (Rect.Create(
-                        bounds.Left,
-                        bounds.Bottom - (a - corner_3) * perimeter |> min bounds.Bottom,
-                        bounds.Left + Style.PADDING,
-                        bounds.Bottom - (b - corner_3) * perimeter |> max bounds.Top
-                    ))
-                    color
-
         override this.Update(elapsed_ms, moved) =
             base.Update(elapsed_ms, moved)
             animation.Update elapsed_ms
@@ -111,10 +58,7 @@ module LoadingIndicator =
 
                 let b = this.Bounds.Expand(Style.PADDING)
                 let x = float32 (animation.Time / animation.Interval)
-                let color = Colors.white.O4a fade.Alpha
-                draw b x 0.1f color
-                draw b (x + 0.333f) 0.1f color
-                draw b (x + 0.666f) 0.1f color
+                LoadingAnimation.draw_border b x (Colors.white.O4a fade.Alpha)
 
 type WIP() as this =
     inherit StaticWidget(NodeType.None)

--- a/interlude/src/UI/Menu/Menu.fs
+++ b/interlude/src/UI/Menu/Menu.fs
@@ -55,7 +55,7 @@ type Page() as this =
         Button(
             Icons.ARROW_LEFT_CIRCLE + " " + %"menu.back",
             Menu.Back,
-            Position = Position.SliceBottom(80.0f).CenterY(55.0f).TrimLeft(10.0f).SliceLeft(180.0f)
+            Position = Position.SliceBottom(80.0f).CenterVertical(55.0f).TrimLeft(10.0f).SliceLeft(180.0f)
         )
         |> OverlayContainer
         :> Widget

--- a/interlude/src/UI/Screen/Screen.fs
+++ b/interlude/src/UI/Screen/Screen.fs
@@ -215,10 +215,7 @@ module Screen =
 
                 Draw.sprite
                     (Rect.Box(x, y, Content.ThemeConfig.CursorSize, Content.ThemeConfig.CursorSize))
-                    (if HelpOverlay.info_available then
-                         Colors.white
-                     else
-                         Palette.color (255, 1.0f, 0.5f))
+                    (Palette.color (255, 1.0f, 0.5f))
                     (Content.Texture "cursor")
 
             perf.Draw()


### PR DESCRIPTION
Upgrade to Interlude's 'ingame help' system
Instead of hovering over things and pressing /, / will toggle an overlay "help mode" that highlights everything with info available

This frees up the concept of actual *tooltips* on hover which much of the UI could benefit from greatly