### PR TITLE
Upgrade OpenTK + Improve GLFW callbacks

### DIFF
--- a/engine/src/Input/Input.fs
+++ b/engine/src/Input/Input.fs
@@ -8,6 +8,8 @@ open Percyqaz.Common
 open Percyqaz.Flux.Graphics
 open Percyqaz.Flux.Audio
 
+
+
 type Keys = OpenTK.Windowing.GraphicsLibraryFramework.Keys
 type MouseButton = OpenTK.Windowing.GraphicsLibraryFramework.MouseButton
 
@@ -155,6 +157,10 @@ module internal InputThread =
 
     let mutable internal game_window: NativeWindow = null
 
+    let private error_callback (code: ErrorCode) (desc: string) =
+        Logging.Debug(sprintf "GLFW Error (%O): %s" code desc)
+    let private error_callback_d = GLFWCallbacks.ErrorCallback error_callback
+
     let init (win: NativeWindow) =
         game_window <- win
         game_window.add_MouseWheel (fun e -> mouse_z <- mouse_z + e.OffsetY)
@@ -169,6 +175,8 @@ module internal InputThread =
                 since_last_typed.Restart()
                 lock LOCK_OBJ (fun () -> typed_text <- typed_text + e.AsString)
         )
+        
+        GLFW.SetErrorCallback(error_callback_d) |> ignore
 
     let fetch (events_this_frame: InputEv list byref, this_frame: FrameEvents byref) =
         let a, b =

--- a/engine/src/Percyqaz.Flux.fsproj
+++ b/engine/src/Percyqaz.Flux.fsproj
@@ -59,7 +59,7 @@
   <ItemGroup>
     <PackageReference Include="ManagedBass" Version="3.1.1" />
     <PackageReference Include="ManagedBass.Fx" Version="3.1.1" />
-    <PackageReference Include="OpenTK" Version="4.7.7" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
 	<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
   </ItemGroup>

--- a/engine/src/Windowing/Window.fs
+++ b/engine/src/Windowing/Window.fs
@@ -323,7 +323,7 @@ type Window(config: Config, title: string, ui_root: Root) as this =
                     Window.action_queue <- []
                 )
 
-            this.ProcessInputEvents()
+            this.NewInputFrame()
             if input_cpu_saver then
                 GLFW.WaitEventsTimeout(0.5)
             else

--- a/engine/src/Windowing/Window.fs
+++ b/engine/src/Windowing/Window.fs
@@ -323,12 +323,10 @@ type Window(config: Config, title: string, ui_root: Root) as this =
                     Window.action_queue <- []
                 )
 
-            this.NewInputFrame()
             if input_cpu_saver then
                 GLFW.WaitEventsTimeout(0.5)
             else
                 GLFW.PollEvents()
-            InputThread.poll (this.KeyboardState, this.MouseState)
 
         this.OnUnload()
         this.Close()

--- a/interlude/src/Features/Skins/EditHUD/EditScreen.fs
+++ b/interlude/src/Features/Skins/EditHUD/EditScreen.fs
@@ -81,10 +81,6 @@ type Positioner(elem: HudElement, ctx: PositionerContext) =
 
     let mutable dragging_from: (float32 * float32) option = None
     let mutable hover = false
-    let mutable repeat = -1
-    let mutable time = 0.0
-    let REPEAT_DELAY = 400.0
-    let REPEAT_INTERVAL = 40.0
 
     let SMALL_UP = (%%"up").WithModifiers(false, false, true)
     let SMALL_DOWN = (%%"down").WithModifiers(false, false, true)
@@ -371,57 +367,15 @@ type Positioner(elem: HudElement, ctx: PositionerContext) =
         let mutable moved = moved
 
         if this.Focused then
-            if SMALL_UP.Tapped() then this.Move(0.0f, -1.0f)
-            elif SMALL_DOWN.Tapped() then this.Move(0.0f, 1.0f)
-            elif SMALL_LEFT.Tapped() then this.Move(-1.0f, 0.0f)
-            elif SMALL_RIGHT.Tapped() then this.Move(1.0f, 0.0f)
+            if SMALL_UP.TappedOrRepeated() then this.Move(0.0f, -1.0f)
+            elif SMALL_DOWN.TappedOrRepeated() then this.Move(0.0f, 1.0f)
+            elif SMALL_LEFT.TappedOrRepeated() then this.Move(-1.0f, 0.0f)
+            elif SMALL_RIGHT.TappedOrRepeated() then this.Move(1.0f, 0.0f)
 
-            let u = (%%"up").Tapped()
-            let d = (%%"down").Tapped()
-            let l = (%%"left").Tapped()
-            let r = (%%"right").Tapped()
-
-            if u || d || l || r then
-                repeat <- 0
-                time <- 0
-
-                if u then
-                    this.Move(0.0f, -5.0f)
-
-                if d then
-                    this.Move(0.0f, 5.0f)
-
-                if l then
-                    this.Move(-5.0f, 0.0f)
-
-                if r then
-                    this.Move(5.0f, 0.0f)
-
-            if repeat >= 0 then
-                let u = (%%"up").Pressed()
-                let d = (%%"down").Pressed()
-                let l = (%%"left").Pressed()
-                let r = (%%"right").Pressed()
-
-                time <- time + elapsed_ms
-
-                if (float repeat * REPEAT_INTERVAL + REPEAT_DELAY < time) then
-                    repeat <- repeat + 1
-
-                    if u then
-                        this.Move(0.0f, -5.0f)
-
-                    if d then
-                        this.Move(0.0f, 5.0f)
-
-                    if l then
-                        this.Move(-5.0f, 0.0f)
-
-                    if r then
-                        this.Move(5.0f, 0.0f)
-
-                if not (u || d || l || r) then
-                    repeat <- -1
+            if (%%"up").TappedOrRepeated() then this.Move(0.0f, -5.0f)
+            if (%%"down").TappedOrRepeated() then this.Move(0.0f, 5.0f)
+            if (%%"left").TappedOrRepeated() then this.Move(-5.0f, 0.0f)
+            if (%%"right").TappedOrRepeated() then this.Move(5.0f, 0.0f)
 
         hover <- Mouse.hover this.Bounds
 

--- a/interlude/src/UI/Menu/Slider.fs
+++ b/interlude/src/UI/Menu/Slider.fs
@@ -115,13 +115,13 @@ type Slider(setting: Setting.Bounded<float32>) =
 
         if this.Selected then
 
-            if (%%"left").Tapped() then
+            if (%%"left").TappedOrRepeated() then
                 add (-step)
-            elif (%%"right").Tapped() then
+            elif (%%"right").TappedOrRepeated() then
                 add (step)
-            elif (%%"up").Tapped() then
+            elif (%%"up").TappedOrRepeated() then
                 add (step * 5.0f)
-            elif (%%"down").Tapped() then
+            elif (%%"down").TappedOrRepeated() then
                 add (-step * 5.0f)
             elif (%%"select").Tapped() then
                 typed_number.Set ""


### PR DESCRIPTION
Aim: Fix bug reported by @9382:
Attempting to paste a the clipboard while it contains an image (or a file via right click -> copy, anything not convertible to text) will cause an error inside GLFW

GLFW calls the error callback when the clipboard fails right before it releases the clipboard, so due to some kind of thread theft by OpenTK's error callback the clipboard is never released

Replacing the callback with something else fixes it (all discovered by @9382)

Bonus part of this PR:
I've wanted to refactor to cut out OpenTK's middle manning in input handling and just use GLFW callbacks directly for everything so refactoring to do that

As a result:
- Can listen to key repeats properly, based on the repeat speed user has set in their desktop environment
- Input should be faster (Won't break my back measuring it, but it should be marginally faster if any change at all due to simply doing less stuff)
- Input code is less of a rats nest