### PR TITLE
Slightly reduce lag when consuming a ScrollTo.Chart

### DIFF
--- a/interlude/src/Features/LevelSelect/Tree/Charts.fs
+++ b/interlude/src/Features/LevelSelect/Tree/Charts.fs
@@ -218,8 +218,4 @@ type private ChartItem(group_name: string, group_ctx: LibraryGroupContext, cc: C
         hover.Update(elapsed_ms) |> ignore
 
     member this.Update(top, origin, originB, elapsed_ms) =
-        if scroll_to = ScrollTo.Chart && (group_name, group_ctx) = selected_group && this.Selected then
-            scroll (-top + 500.0f)
-            scroll_to <- ScrollTo.Nothing
-
         this.CheckBounds(top, origin, originB, (fun b -> this.OnUpdate(origin, b, elapsed_ms)))

--- a/interlude/src/Features/LevelSelect/Tree/Groups.fs
+++ b/interlude/src/Features/LevelSelect/Tree/Groups.fs
@@ -120,15 +120,11 @@ type private GroupItem(name: string, items: ResizeArray<ChartItem>, context: Lib
         if this.Expanded then
             let h = CHART_HEIGHT + 5.0f
 
-            let mutable index =
-                if scroll_to <> ScrollTo.Nothing then
-                    0
-                else
-                    (origin - b) / h |> floor |> int |> max 0
+            let mutable index = (origin - b) / h |> floor |> int |> max 0
 
             let mutable p = b + float32 index * h
 
-            while (scroll_to <> ScrollTo.Nothing || p < originB) && index < items.Count do
+            while p < originB && index < items.Count do
                 p <- items.[index].Draw(p, origin, originB)
                 index <- index + 1
 

--- a/interlude/src/Features/LevelSelect/Tree/Groups.fs
+++ b/interlude/src/Features/LevelSelect/Tree/Groups.fs
@@ -199,19 +199,18 @@ type private GroupItem(name: string, items: ResizeArray<ChartItem>, context: Lib
 
             let h = CHART_HEIGHT + 5.0f
 
-            let mutable index =
-                if scroll_to <> ScrollTo.Nothing then
-                    0
-                else
-                    (origin - b) / h |> floor |> int |> max 0
+            if scroll_to = ScrollTo.Chart && this.Selected then
+                let i = Seq.findIndex (fun (s: ChartItem) -> s.Selected) items
+                scroll (-(b + float32 i * h) + 500.0f)
+                scroll_to <- ScrollTo.Nothing
 
+            let mutable index = (origin - b) / h |> floor |> int |> max 0
             let mutable p = b + float32 index * h
 
-            while (scroll_to <> ScrollTo.Nothing || p < originB) && index < items.Count do
+            while p < originB && index < items.Count do
                 p <- items.[index].Update(p, origin, originB, elapsed_ms)
                 index <- index + 1
 
-            b + float32 items.Count * (CHART_HEIGHT + 5.0f)
-            
+            b + float32 items.Count * h
         else
             b


### PR DESCRIPTION
Ideally there'd be some way to cache the index, but I'm not familiar enough with the whole system to trust myself implementing that, so I'll take the easier solution of a more trivial optimisation. Also, this situation rarely arises, so it's not critical that it needs to be insanely fast, it just slightly annoyed me that the F4 graph was increasing by that much
(this is way more noticable if you disable the scroll_to_chart_once feature)