### PR TITLE
Overhaul chart origin tracking

### DIFF
--- a/interlude/src/Features/Printerlude/Printerlude.fs
+++ b/interlude/src/Features/Printerlude/Printerlude.fs
@@ -27,21 +27,10 @@ module Printerlude =
 
     module private Utils =
 
-        let mutable cmp = None
-
-        let cmp_1 () =
-            match SelectedChart.CHART with
+        let chart_info () =
+            match SelectedChart.CACHE_DATA with
             | None -> failwith "Select a chart"
-            | Some c -> cmp <- Some c
-
-        let cmp_2 () =
-            match cmp with
-            | None -> failwith "Use cmp_1 first"
-            | Some cmp ->
-
-            match SelectedChart.CHART with
-            | None -> failwith "Select a chart"
-            | Some c -> Chart.diff cmp c
+            | Some c -> Logging.Debug "%A" c
 
         let show_version (io: IOContext) =
             io.WriteLine(sprintf "You are running %s" Updates.version)
@@ -145,8 +134,7 @@ module Printerlude =
                 .WithCommand("enable_experiments", "Enables/disables developer experiments", "enabled", toggle_experiments)
                 .WithCommand("banner", "Generates a banner image (for testing)", "color", "emoji", banner)
                 .WithCommand("fake_update", "Fakes an update for testing the update UI button", fun () -> if Updates.latest_release.IsSome then Updates.update_available <- true)
-                .WithCommand("cmp_1", "Select chart to compare against", cmp_1)
-                .WithCommand("cmp_2", "Compare current chart to selected chart", cmp_2)
+                .WithCommand("chart_info", "Dumps chart meta info", chart_info)
                 .WithCommand("vacuum", "Debug tool for cleaning up chart database", vacuum)
 
         let register_ipc_commands (ctx: ShellContext) =

--- a/online/server/Domain/Backbeat/Songs.fs
+++ b/online/server/Domain/Backbeat/Songs.fs
@@ -38,7 +38,7 @@ module Songs =
             );
 
             CREATE TRIGGER songs_fts_ai AFTER INSERT ON songs BEGIN
-              INSERT INTO songs_fts(Id, Artists, OtherArtists, Remixers, Title, AlternativeTitles, Source) 
+              INSERT INTO songs_fts(Id, Artists, OtherArtists, Remixers, Title, AlternativeTitles, Source)
               VALUES (new.Id, new.Artists, new.OtherArtists, new.Remixers, new.Title, new.AlternativeTitles, new.Source);
             END;
 
@@ -46,7 +46,7 @@ module Songs =
               DELETE FROM songs_fts
               WHERE rowid = old.Id;
 
-              INSERT INTO songs_fts(Id, Artists, OtherArtists, Remixers, Title, AlternativeTitles, Source) 
+              INSERT INTO songs_fts(Id, Artists, OtherArtists, Remixers, Title, AlternativeTitles, Source)
               VALUES (new.Id, new.Artists, new.OtherArtists, new.Remixers, new.Title, new.AlternativeTitles, new.Source);
             END;
 
@@ -54,7 +54,7 @@ module Songs =
                 DELETE FROM songs_fts
                 WHERE rowid = old.Id;
             END;
-            
+
             CREATE TABLE charts (
                 Id TEXT PRIMARY KEY NOT NULL,
                 SongId INTEGER NOT NULL,
@@ -103,7 +103,7 @@ module Songs =
                         BPM = r.Json JSON
                         BackgroundHash = r.String
                         AudioHash = r.String
-                        Sources = r.Json JSON
+                        Origins = r.Json JSON
                     }
                 )
         }
@@ -115,7 +115,7 @@ module Songs =
         {
             SQL =
                 """
-            SELECT 
+            SELECT
                 charts.SongId, charts.Creators, charts.DifficultyName, charts.Subtitle,
                 charts.Tags, charts.Duration, charts.PreviewTime, charts.Notecount,
                 charts.Keys, charts.BPM, charts.BackgroundHash, charts.AudioHash, charts.Sources,
@@ -142,7 +142,7 @@ module Songs =
                         BPM = r.Json JSON
                         BackgroundHash = r.String
                         AudioHash = r.String
-                        Sources = r.Json JSON
+                        Origins = r.Json JSON
                     },
                     {
                         Artists = r.Json JSON
@@ -231,7 +231,7 @@ module Songs =
             INSERT INTO charts (Id, SongId, Creators, DifficultyName, Subtitle, Tags, Duration, PreviewTime, Notecount, Keys, BPM, BackgroundHash, AudioHash, Sources, LastUpdated)
             VALUES (@ChartId, last_insert_rowid(), @Creators, @DifficultyName, @Subtitle, @ChartTags, @Duration, @PreviewTime, @Notecount, @Keys, @BPM, @BackgroundHash, @AudioHash, @Sources, @LastUpdated)
             RETURNING SongId;
-            
+
             COMMIT;
             """
             Parameters =
@@ -279,7 +279,7 @@ module Songs =
                     p.Json JSON chart.BPM
                     p.String chart.BackgroundHash
                     p.String chart.AudioHash
-                    p.Json JSON chart.Sources
+                    p.Json JSON chart.Origins
                     p.Int64(Timestamp.now ())
                 )
             Read = fun r -> r.Int64
@@ -330,7 +330,7 @@ module Songs =
                     p.Json JSON chart.BPM
                     p.String chart.BackgroundHash
                     p.String chart.AudioHash
-                    p.Json JSON chart.Sources
+                    p.Json JSON chart.Origins
                     p.Int64(Timestamp.now ())
                 )
         }
@@ -358,9 +358,9 @@ module Songs =
         }
 
     let merge_songs (duplicate_song_id: int64) (original_song_id: int64) : bool =
-        if duplicate_song_id = original_song_id then 
-            false 
-        else 
+        if duplicate_song_id = original_song_id then
+            false
+        else
             MERGE_SONGS.Execute (duplicate_song_id, original_song_id) backbeat_db
             |> expect > 0
 
@@ -369,7 +369,7 @@ module Songs =
             SQL =
                 """
             UPDATE charts
-            SET 
+            SET
                 Creators = @Creators,
                 DifficultyName = @DifficultyName,
                 Subtitle = @Subtitle,
@@ -416,7 +416,7 @@ module Songs =
                     p.Json JSON chart.BPM
                     p.String chart.BackgroundHash
                     p.String chart.AudioHash
-                    p.Json JSON chart.Sources
+                    p.Json JSON chart.Origins
                     p.Int64(Timestamp.now ())
                 )
         }

--- a/online/server/Domain/Database.fs
+++ b/online/server/Domain/Database.fs
@@ -70,6 +70,11 @@ module Migrations =
             (fun _ -> Logging.Info("Old backbeat chart dump no longer exists to migrate data from"))
             db
 
+        Database.migrate
+            "ResetChartOrigins"
+            (fun db -> Database.exec_raw """UPDATE charts SET Sources = '[]';""" db |> expect |> ignore)
+            db
+
 module Database =
 
     let startup () =

--- a/online/shared/API.fs
+++ b/online/shared/API.fs
@@ -4,6 +4,7 @@ open System
 open System.Web
 open System.Net
 open System.Net.Sockets
+open System.Diagnostics
 open NetCoreServer
 open Percyqaz.Common
 open Prelude
@@ -51,6 +52,7 @@ module API =
                 |> Map.ofSeq
 
             try
+                let before = Stopwatch.GetTimestamp()
                 match request.Method with
                 | "GET" ->
                     config.Handle_Request(GET, uri.AbsolutePath, request.Body, query_params, headers, this.Response)
@@ -62,6 +64,8 @@ module API =
                     config.Handle_Request(POST, uri.AbsolutePath, request.Body, query_params, headers, this.Response)
                     |> Async.RunSynchronously
                 | _ -> this.Response.MakeErrorResponse(404, "Not found") |> ignore
+
+                Logging.Info "%s responded %i in %.0fms" uri.AbsolutePath this.Response.Status (Stopwatch.GetElapsedTime(before).TotalMilliseconds)
 
                 this.SendResponseAsync this.Response |> ignore
             with e ->

--- a/online/shared/Server.fs
+++ b/online/shared/Server.fs
@@ -85,7 +85,7 @@ module Server =
             try
                 session.Send packet_with_header |> ignore
             with :? ObjectDisposedException ->
-                Logging.Debug("Socket was disposed before packet could be sent")
+                Logging.Debug "Socket was disposed before packet could be sent"
 
     let kick (id: Guid, reason: string) =
         Logging.Info "Kicking session %O: %s" id reason

--- a/online/tests/domain/Backbeat/Songs.fs
+++ b/online/tests/domain/Backbeat/Songs.fs
@@ -3,6 +3,7 @@
 open NUnit.Framework
 
 open Prelude
+open Prelude.Charts
 open Prelude.Backbeat.Archive
 open Interlude.Web.Server.Domain.Backbeat
 
@@ -37,7 +38,7 @@ module Songs =
             BPM = random.NextSingle() * 1000.0f<ms / beat>, random.NextSingle() * 1000.0f<ms / beat>
             BackgroundHash = random_text 15
             AudioHash = random_text 15
-            Sources = [ Etterna "Nanahira Minipack" ]
+            Origins = Set.ofList [ ChartOrigin.Etterna "Nanahira Minipack" ]
         }
 
     let TEST_SONG: Song =
@@ -67,7 +68,7 @@ module Songs =
             BPM = 413.7931f<ms / beat>, 413.7931f<ms / beat>
             BackgroundHash = "823436D6ED4350C2ED3ED6CC8502B69207F2670E60C6B5EAF6AB1A01744BD750"
             AudioHash = "D0AC559C92AE400A3A2C95EA0ED0E9034798634E1AF60ACAD99C6FA272631B89"
-            Sources = [ Etterna "Nanahira Minipack" ]
+            Origins = Set.ofList [ ChartOrigin.Etterna "Nanahira Minipack" ]
         }
 
     [<Test>]
@@ -301,7 +302,7 @@ module Songs =
         Assert.AreEqual(None, Songs.song_by_id song_id_1)
         Assert.AreEqual(Some(song_id_2, song_2), Songs.song_by_chart_id chart_id_1)
         Assert.AreEqual(Some(song_id_2, song_2), Songs.song_by_chart_id chart_id_2)
-    
+
     [<Test>]
     let MergeSongs_MultipleChartsOnDuplicateSong () =
         let chart_id_1 = "mergesongs3"
@@ -326,7 +327,7 @@ module Songs =
         Assert.AreEqual(Some(song_id_2, song_2), Songs.song_by_chart_id chart_id_1)
         Assert.AreEqual(Some(song_id_2, song_2), Songs.song_by_chart_id chart_id_2)
         Assert.AreEqual(Some(song_id_2, song_2), Songs.song_by_chart_id chart_id_3)
-    
+
     [<Test>]
     let MergeSongs_RemovedFromFTS () =
         let chart_id_1 = "mergesongs_fts"
@@ -341,7 +342,7 @@ module Songs =
         let song_id_2 = Songs.add_chart_song chart_id_2 chart_2 song_2
 
         Assert.True(Songs.merge_songs song_id_1 song_id_2)
-        
+
         let results = Songs.search_songs 20L 0 song_1.Title
         printfn "%A" results
         Assert.IsEmpty results
@@ -394,7 +395,7 @@ module Songs =
         let chart = generate_test_chart ()
         let song = generate_test_song()
         let song_id = Songs.add_chart_song chart_id chart song
-        
+
         let results_before = Songs.search_songs 20L 0 song.Title
         printfn "%A" results_before
 
@@ -404,7 +405,7 @@ module Songs =
         printfn "%A" results
 
         match results |> Array.tryFind (fun (id, _) -> id = song_id) with
-        | Some (_, found) -> 
+        | Some (_, found) ->
             printfn "Deleted song: %A\nbut found song: %A" song found
             Assert.Fail()
         | None -> Assert.Pass()

--- a/prelude/playground/Tools/OsuReplayGenerator.fs
+++ b/prelude/playground/Tools/OsuReplayGenerator.fs
@@ -44,7 +44,7 @@ let generate_scenario (notes: TimeArray<NoteRow>) (replay: ReplayData) (od: floa
             PreviewTime = 0.0f<ms>
 
             Packs = Set.empty
-            Origin = ChartOrigin.Unknown
+            Origins = Set.empty
 
             Keys = 4
             Length = 0.0f<ms>

--- a/prelude/src/Charts/Conversions/Quaver.fs
+++ b/prelude/src/Charts/Conversions/Quaver.fs
@@ -144,6 +144,11 @@ module Quaver_To_Interlude =
 
             let path = Path.GetDirectoryName action.Source
 
+            let md5 =
+                match QuaverChart.HashFromFile action.Source with
+                | Ok s -> s
+                | Error reason -> skip_conversion (sprintf "Failed to calculate MD5 of .qua file: %s" reason)
+
             let header =
                 {
                     Title = b.Title
@@ -178,7 +183,7 @@ module Quaver_To_Interlude =
                         else
                             ImportAsset.Missing
 
-                    ChartSource = ImportOrigin.Quaver(b.MapSetId, b.MapId)
+                    Origins = Set.singleton <| ChartOrigin.Quaver(md5, b.MapSetId, b.MapId)
                 }
 
             let snaps = convert_hit_objects b.HitObjects keys

--- a/prelude/src/Charts/Conversions/StepMania.fs
+++ b/prelude/src/Charts/Conversions/StepMania.fs
@@ -294,10 +294,10 @@ module StepMania_To_Interlude =
                                 //Logging.Warn "Background file for %s not found: %s" path sm.BACKGROUND
                                 ImportAsset.Missing
 
-                        ChartSource =
+                        Origins =
                             match action.Config.EtternaPackName with
-                            | Some pack -> ImportOrigin.Etterna pack
-                            | None -> ImportOrigin.Unknown
+                            | Some pack -> Set.singleton (ChartOrigin.Etterna pack)
+                            | None -> Set.empty
                     }
 
                 let (keys, notes, bpm) =

--- a/prelude/src/Charts/Conversions/osu!.fs
+++ b/prelude/src/Charts/Conversions/osu!.fs
@@ -206,6 +206,11 @@ module Osu_To_Interlude =
                 | _ :: es -> find_background_file es
                 | [] -> ""
 
+            let md5 =
+                match Beatmap.HashFromFile action.Source with
+                | Ok s -> s
+                | Error reason -> skip_conversion (sprintf "Failed to calculate MD5 of .osu file: %s" reason)
+
             let header =
                 {
                     Title = b.Metadata.Title.Trim()
@@ -252,7 +257,7 @@ module Osu_To_Interlude =
                         else
                             ImportAsset.Missing
 
-                    ChartSource = ImportOrigin.Osu(b.Metadata.BeatmapSetID, b.Metadata.BeatmapID)
+                    Origins = Set.singleton <| ChartOrigin.Osu(md5, b.Metadata.BeatmapSetID, b.Metadata.BeatmapID, None)
                 }
 
             let snaps = convert_hit_objects b.Objects keys

--- a/prelude/src/Charts/Formats/Interlude/Interlude.fs
+++ b/prelude/src/Charts/Formats/Interlude/Interlude.fs
@@ -34,15 +34,6 @@ type ImportAsset =
     | Asset of string // deprecated
     | Missing
 
-[<Json.AutoCodec>]
-[<RequireQualifiedAccess>]
-type ImportOrigin =
-    | Osu of beatmapsetid: int * beatmapid: int
-    | Quaver of mapsetid: int * mapid: int
-    | Etterna of pack_name: string
-    | Stepmania of packid: int // deprecated
-    | Unknown
-
 [<Json.AutoCodec(false)>]
 type ChartImportHeader =
     {
@@ -60,7 +51,7 @@ type ChartImportHeader =
         BackgroundFile: ImportAsset
         AudioFile: ImportAsset
 
-        ChartSource: ImportOrigin
+        mutable Origins: Set<ChartOrigin>
     }
     static member Default =
         {
@@ -78,7 +69,7 @@ type ChartImportHeader =
             BackgroundFile = ImportAsset.Missing
             AudioFile = ImportAsset.Missing
 
-            ChartSource = ImportOrigin.Unknown
+            Origins = Set.empty
         }
 
 type ImportChart =

--- a/prelude/src/Charts/Formats/Interlude/Types.fs
+++ b/prelude/src/Charts/Formats/Interlude/Types.fs
@@ -1,6 +1,7 @@
 ﻿namespace Prelude.Charts
 
 open System.IO
+open Percyqaz.Data
 open Prelude
 
 type NoteType =
@@ -89,3 +90,22 @@ type BPM =
     }
 
 type SV = float32
+
+[<Json.AutoCodec>]
+[<RequireQualifiedAccess>]
+type ChartOrigin =
+    | Osu of md5: string * beatmapsetid: int * beatmapid: int * from_rate: (float32<rate> * float32<ms>) option
+    | Quaver of md5: string * mapsetid: int * mapid: int
+    | Etterna of pack_name: string
+
+    override this.ToString() =
+        match this with
+        | Osu _ -> "osu!"
+        | Quaver _ -> "Quaver"
+        | Etterna pack -> pack
+
+    member this.SuitableForUpload =
+        match this with
+        | Osu (_, beatmapsetid, beatmapid, _) -> beatmapsetid <> -1 && beatmapid <> 0
+        | Quaver (_, mapsetid, mapid) -> mapsetid <> -1 && mapid <> 0
+        | Etterna _ -> true

--- a/prelude/src/Charts/Formats/Quaver.fs
+++ b/prelude/src/Charts/Formats/Quaver.fs
@@ -49,6 +49,17 @@ type QuaverChart =
         HitObjects: QuaverHitObject list
     }
 
+    static member Hash(stream: Stream) =
+        let md5 = System.Security.Cryptography.MD5.Create()
+        md5.ComputeHash(stream) |> Convert.ToHexString |> _.ToLower()
+
+    static member HashFromFile(path: string) : Result<string, string> =
+        try
+            use fs = File.OpenRead(path)
+            Ok(QuaverChart.Hash fs)
+        with err ->
+            Error err.Message
+
 // only parses a smaller subset of yaml that quaver uses
 module Yaml =
     type ParsedYamlNestedObject = Map<string, string>

--- a/prelude/src/Data/Library/ChartDatabase.fs
+++ b/prelude/src/Data/Library/ChartDatabase.fs
@@ -24,7 +24,7 @@ type ChartDatabase =
 
 module ChartDatabase =
 
-    (* Retrival operations *)
+    (* Retrieval operations *)
 
     let get_chart (chart_id: string) (db: ChartDatabase) : Result<Chart, string> =
         DbCharts.get_chart chart_id db.Database
@@ -177,6 +177,7 @@ module ChartDatabase =
 
     let private migrate (db: Database) : Database =
         Database.migrate "AddChartsTable" (fun db -> DbCharts.CREATE_TABLE.Execute () db |> expect |> ignore) db
+        Database.migrate "ResetOriginsColumn" (fun db -> DbCharts.RESET_ORIGINS.Execute () db |> expect |> ignore) db
         db
 
     let private legacy_migrate (db: ChartDatabase) : ChartDatabase =

--- a/prelude/src/Data/Library/Charts.fs
+++ b/prelude/src/Data/Library/Charts.fs
@@ -88,23 +88,6 @@ module DbCharts =
                     Audio = excluded.Audio,
                     PreviewTime = excluded.PreviewTime,
                     DateAdded = excluded.DateAdded,
-                    Origin = (
-                        SELECT '[' || group_concat(value) || ']' FROM (
-                            SELECT json_each.value
-                            FROM charts, json_each(charts.Origin)
-                            WHERE charts.Id = excluded.Id
-                            UNION
-                            SELECT json_each.value
-                            FROM json_each(excluded.Origin)
-                        ) GROUP BY ''
-                    ),
-                    Length = excluded.Length,
-                    BPM = excluded.BPM,
-                    DateAdded = excluded.DateAdded,
-                    CalcVersion = excluded.CalcVersion,
-                    Rating = excluded.Rating,
-                    Patterns = excluded.Patterns,
-                    Chart = excluded.Chart,
                     Packs = (
                         SELECT json_group_array(value) FROM (
                             SELECT json_each.value
@@ -113,8 +96,25 @@ module DbCharts =
                             UNION
                             SELECT json_each.value
                             FROM json_each(excluded.Packs)
-                        ) GROUP BY ''
-                    );
+                        )
+                    ),
+                    Origin = (
+                        SELECT coalesce('[' || group_concat(value) || ']', '[]') FROM (
+                            SELECT json_each.value
+                            FROM charts, json_each(charts.Origin)
+                            WHERE charts.Id = excluded.Id
+                            UNION
+                            SELECT json_each.value
+                            FROM json_each(excluded.Origin)
+                        )
+                    ),
+                    Length = excluded.Length,
+                    BPM = excluded.BPM,
+                    DateAdded = excluded.DateAdded,
+                    CalcVersion = excluded.CalcVersion,
+                    Rating = excluded.Rating,
+                    Patterns = excluded.Patterns,
+                    Chart = excluded.Chart;
             """
             Parameters =
                 [

--- a/prelude/src/Data/Library/Imports.fs
+++ b/prelude/src/Data/Library/Imports.fs
@@ -89,8 +89,7 @@ module Imports =
                                 then
                                     match import.Header.Origins |> Set.toSeq |> Seq.tryHead with
                                     | Some (ChartOrigin.Osu (md5, set_id, map_id, _)) ->
-                                        let offset = import.Chart.FirstNote * float32 rate - original.FirstNote
-                                        Some (header, ChartOrigin.Osu (md5, set_id, map_id, Some (rate, offset)))
+                                        Some (header, ChartOrigin.Osu (md5, set_id, map_id, Some (rate, import.Chart.FirstNote)))
                                     | _ -> None
                                 else None
                             | _ -> None

--- a/prelude/tests/Database/DbCharts.fs
+++ b/prelude/tests/Database/DbCharts.fs
@@ -33,7 +33,7 @@ module DbCharts =
             Audio = AssetPath.Missing
             PreviewTime = 1000.0f<ms>
             Packs = Set.singleton "Singles"
-            Origin = ChartOrigin.Etterna "Bangers and Mash"
+            Origins = Set.singleton (ChartOrigin.Etterna "Bangers and Mash")
             Keys = 4
             Length = 0.0f<ms>
             BPM = 120
@@ -58,7 +58,7 @@ module DbCharts =
             Audio = AssetPath.Absolute "C:/path/to/audio.mp3"
             PreviewTime = 2000.0f<ms>
             Packs = Set.singleton "Nanahira Minipack"
-            Origin = ChartOrigin.Etterna "Nanahira Minipack"
+            Origins = Set.singleton (ChartOrigin.Etterna "Nanahira Minipack")
             Keys = 4
             Length = 1.0f<ms>
             BPM = 121
@@ -101,11 +101,11 @@ module DbCharts =
         Assert.AreEqual(Some TEST_CHART_META, result)
 
         Assert.AreEqual(None, DbCharts.get_meta "doesntexist" db)
-    
+
     [<Test>]
     let RoundTrip_Meta_With_NaN() =
         let db, conn = in_memory ()
-        
+
         DbCharts.delete TEST_CHART_META.Hash db |> ignore
 
         DbCharts.save TEST_CHART_META_NAN TEST_CHART db
@@ -119,7 +119,7 @@ module DbCharts =
         DbCharts.save TEST_CHART_META TEST_CHART db
         let result = DbCharts.get_chart TEST_CHART_META.Hash db
         match result with
-        | Ok chart -> 
+        | Ok chart ->
             Assert.AreEqual(TEST_CHART_META.Hash, Chart.hash chart)
         | Error reason -> Assert.Fail(reason)
 
@@ -133,11 +133,11 @@ module DbCharts =
         | Error reason -> Assert.Pass(reason)
 
         conn.Dispose()
-    
+
     [<Test>]
     let Chart_Delete () =
         let db, conn = in_memory ()
-        
+
         DbCharts.save TEST_CHART_META TEST_CHART db
         let result = DbCharts.get_meta TEST_CHART_META.Hash db
 
@@ -150,11 +150,11 @@ module DbCharts =
         Assert.False(DbCharts.delete TEST_CHART_META.Hash db)
 
         conn.Dispose()
-    
+
     [<Test>]
     let Chart_Batch_Delete () =
         let db, conn = in_memory ()
-        
+
         DbCharts.save TEST_CHART_META TEST_CHART db
         let result = DbCharts.get_meta TEST_CHART_META.Hash db
 
@@ -178,7 +178,11 @@ module DbCharts =
         Assert.AreEqual(Some TEST_CHART_META, DbCharts.get_meta TEST_CHART_META.Hash db)
 
         DbCharts.save TEST_CHART_META_ALT TEST_CHART db
-        let with_both_packs = { TEST_CHART_META_ALT with Packs = Set.union TEST_CHART_META.Packs TEST_CHART_META_ALT.Packs }
-        Assert.AreEqual(Some with_both_packs, DbCharts.get_meta TEST_CHART_META.Hash db)
+        let with_merged_data =
+            { TEST_CHART_META_ALT with
+                Packs = Set.union TEST_CHART_META.Packs TEST_CHART_META_ALT.Packs
+                Origins = Set.union TEST_CHART_META.Origins TEST_CHART_META_ALT.Origins
+            }
+        Assert.AreEqual(Some with_merged_data, DbCharts.get_meta TEST_CHART_META.Hash db)
 
         conn.Dispose()

--- a/prelude/tests/Database/DbCharts.fs
+++ b/prelude/tests/Database/DbCharts.fs
@@ -186,3 +186,21 @@ module DbCharts =
         Assert.AreEqual(Some with_merged_data, DbCharts.get_meta TEST_CHART_META.Hash db)
 
         conn.Dispose()
+
+    [<Test>]
+    let RoundTrip_Chart_Overwriting_EmptyOrigins() =
+        let db, conn = in_memory ()
+
+        DbCharts.delete TEST_CHART_META.Hash db |> ignore
+
+        DbCharts.save { TEST_CHART_META with Origins = Set.empty } TEST_CHART db
+
+        DbCharts.save { TEST_CHART_META_ALT with Origins = Set.empty } TEST_CHART db
+        let with_merged_data =
+            { TEST_CHART_META_ALT with
+                Packs = Set.union TEST_CHART_META.Packs TEST_CHART_META_ALT.Packs
+                Origins = Set.empty
+            }
+        Assert.AreEqual(Some with_merged_data, DbCharts.get_meta TEST_CHART_META.Hash db)
+
+        conn.Dispose()

--- a/tools/Content/Charts/Upload.fs
+++ b/tools/Content/Charts/Upload.fs
@@ -132,7 +132,7 @@ module Upload =
                 Error "Chart is too short"
             else
 
-            if chart_meta.Origin = ChartOrigin.Unknown then
+            if chart_meta.Origins |> Set.exists _.SuitableForUpload then
                 Error "Chart has no source"
             else
 
@@ -154,18 +154,7 @@ module Upload =
 
                         count
                     BPM = (60000.0f<ms/beat> / float32 chart_meta.BPM, 60000.0f<ms/beat> / float32 chart_meta.BPM)
-                    Sources =
-                        match chart_meta.Origin with
-                        | ChartOrigin.Osu(-1, _)
-                        | ChartOrigin.Osu(_, 0)
-                        | ChartOrigin.Quaver(-1, _)
-                        | ChartOrigin.Quaver(_, 0)
-                        | ChartOrigin.Etterna ""
-                        | ChartOrigin.Unknown -> []
-
-                        | ChartOrigin.Osu(set, id) -> [ Backbeat.Archive.ChartSource.Osu {| BeatmapSetId = set; BeatmapId = id |} ]
-                        | ChartOrigin.Quaver (set, id) -> [ Backbeat.Archive.ChartSource.Quaver {| MapsetId = set; MapId = id |} ]
-                        | ChartOrigin.Etterna pack_name -> [ Backbeat.Archive.ChartSource.Etterna pack_name ]
+                    Origins = chart_meta.Origins |> Set.filter _.SuitableForUpload
                     PreviewTime = chart_meta.PreviewTime
                     BackgroundHash = background_hash
                     AudioHash = audio_hash


### PR DESCRIPTION
When Interlude imports a chart, it remembers where it's seen the chart come from e.g. imported from osu! with this beatmap id, imported from this Etterna pack, etc

One chart can have multiple sources

This rework makes the data more complete so it can act as a complete reference to look up a download for the chart

An osu! source tracks:
MD5 hash
Beatmap ID
Beatmap Set ID
If this source is a rate of the imported chart and not its original, then also the rate of the .osu file this MD5, and IDs are for + the timestamp of the first note of this rated chart

A Quaver source tracks:
MD5 hash
Map ID
Mapset ID

An Etterna source tracks:
Just pack name
No ChartKey calculation or anything at the moment because
- I'm too stupid to get it to work
- I don't trust it not to change or be suitable for relying on
So any future features like importing scores from Etterna will come via reading the keys from the database (it's SQLite so it should be easy enough)

As a result of these changes existing data for local users will be wiped but reimporting will update the sources with the new data