### PR TITLE
Letterboxing support

### DIFF
--- a/engine/src/Graphics/Render.fs
+++ b/engine/src/Graphics/Render.fs
@@ -205,10 +205,20 @@ module Render =
     let bounds() = _bounds
 
     /// <summary>
-    /// Gets the real dimensions of the viewport, as screen pixels.<br/>
-    /// This is not necessarily the dimensions of the window, as this does not include the window border/decorations.
+    /// Gets the real dimensions of the framebuffer, as screen pixels.<br/>
+    /// This is not necessarily the dimensions of the window, as this does not include the window border/decorations.<br/>
+    /// This is not necessarily the dimensions of the game UI, as user could be using letterboxing.<br/><br/>
+    /// For the viewport area of the game use <c>viewport_size()</c>
     /// </summary>
-    let viewport_size() = _framebuffer_width, _framebuffer_height
+    let framebuffer_size() = _framebuffer_width, _framebuffer_height
+
+    /// <summary>
+    /// Gets the real dimensions of the viewport, as screen pixels.<br/>
+    /// This is the dimensions of the part of the monitor the game is rendering on.<br/><br/>
+    /// This is not necessarily the dimensions of the window, as this does account for the window border/decorations OR for letterboxing<br/>
+    /// For the viewport area of the game use <c>viewport_size()</c>
+    /// </summary>
+    let viewport_size() = _letterbox_width, _letterbox_height
 
     /// <summary>
     /// Gets and binds an <see cref="FBO"/> from the pool.<br/>
@@ -396,7 +406,7 @@ module Render =
         _letterbox_height <- letterbox_height
 
         GL.Viewport((framebuffer_width - letterbox_width) / 2, (framebuffer_height - letterbox_height) / 2, letterbox_width, letterbox_height)
-        let width, height = float32 framebuffer_width, float32 framebuffer_height
+        let width, height = float32 letterbox_width, float32 letterbox_height
         _width <- (width / height) * 1080.0f
         _height <- 1080.0f
 

--- a/engine/src/Input/Input.fs
+++ b/engine/src/Input/Input.fs
@@ -140,8 +140,8 @@ module internal InputThread =
 
     let private cursor_pos_callback (_: nativeptr<Window>) (x: float) (y: float) =
         lock LOCK_OBJ (fun () ->
-            mouse_x <- Math.Clamp(Render._width / float32 Render._viewport_width * float32 x, 0.0f, Render._width)
-            mouse_y <- Math.Clamp(Render._height / float32 Render._viewport_height * float32 y, 0.0f, Render._height)
+            mouse_x <- Math.Clamp(Render._width / float32 Render._framebuffer_width * float32 x, 0.0f, Render._width)
+            mouse_y <- Math.Clamp(Render._height / float32 Render._framebuffer_height * float32 y, 0.0f, Render._height)
         )
     let private cursor_pos_callback_d = GLFWCallbacks.CursorPosCallback(cursor_pos_callback)
 

--- a/engine/src/Windowing/GameThread.fs
+++ b/engine/src/Windowing/GameThread.fs
@@ -107,9 +107,9 @@ module GameThread =
     let has_fatal_error () =
         fatal_error
 
-    let internal viewport_resized(width, height) =
+    let internal framebuffer_resized framebuffer viewport =
         assert(is_game_thread())
-        Render.viewport_resized (width, height)
+        Render.framebuffer_resized framebuffer viewport
         resized <- true
 
     let internal change_mode (frame_limit: FrameLimit, refresh_rate: int, entire_monitor: bool, monitor: nativeptr<Monitor>) =
@@ -176,7 +176,7 @@ module GameThread =
         let before_draw = now ()
         Render.start ()
 
-        if Render._viewport_height > 0 then
+        if Render._framebuffer_height > 0 then
             ui_root.Draw()
 
         Render.finish ()
@@ -199,7 +199,7 @@ module GameThread =
 
     let private main_loop () =
         GLFW.MakeContextCurrent(window)
-        Render.init Render.DEFAULT_SCREEN
+        Render.init Render.DEFAULT_SCREEN Render.DEFAULT_SCREEN
 
         match loading_icon with
         | Some icon -> () // todo: get it to work

--- a/engine/src/Windowing/WindowOptions.fs
+++ b/engine/src/Windowing/WindowOptions.fs
@@ -5,6 +5,7 @@ type WindowType =
     | Borderless = 1
     | Fullscreen = 2
     | BorderlessNoTaskbar = 3
+    | FullscreenLetterbox = 4
 
 module WindowResolution =
 

--- a/engine/src/Windowing/WindowOptions.fs
+++ b/engine/src/Windowing/WindowOptions.fs
@@ -61,6 +61,6 @@ type WindowOptions =
         AudioDevicePeriod: int
         AudioDeviceBufferLengthMultiplier: int
         InputCPUSaver: bool
-        EnableCursor: bool
+        HideCursor: bool
         MSAASamples: int
     }

--- a/engine/src/Windowing/WindowThread.fs
+++ b/engine/src/Windowing/WindowThread.fs
@@ -233,13 +233,7 @@ module WindowThread =
 
         refresh_rate <- NativePtr.read(GLFW.GetVideoMode(monitor_ptr)).RefreshRate
 
-        if config.EnableCursor then
-            GLFW.SetInputMode(window, CursorStateAttribute.Cursor, CursorModeValue.CursorNormal)
-        elif OperatingSystem.IsMacOS() && GLFW.RawMouseMotionSupported() then
-            GLFW.SetInputMode(window, RawMouseMotionAttribute.RawMouseMotion, true)
-            GLFW.SetInputMode(window, CursorStateAttribute.Cursor, CursorModeValue.CursorDisabled)
-        else
-            GLFW.SetInputMode(window, CursorStateAttribute.Cursor, CursorModeValue.CursorHidden)
+        InputThread.set_cursor_hidden config.HideCursor window
 
         let x, y = GLFW.GetWindowPos(window)
         let width, height = GLFW.GetWindowSize(window)
@@ -388,6 +382,7 @@ module WindowThread =
         letterbox <- if config.WindowMode = WindowType.FullscreenLetterbox then Some (config.FullscreenVideoMode.Width, config.FullscreenVideoMode.Height) else None
         framebuffer_size_callback window width height
 
+        GLFW.SetInputMode(window, RawMouseMotionAttribute.RawMouseMotion, true)
         Input.init window
 
         GLFW.SetDropCallback(window, file_drop_callback_d) |> ignore

--- a/interlude/src/Options/Window.fs
+++ b/interlude/src/Options/Window.fs
@@ -62,7 +62,7 @@ type WindowSettings =
             AudioDevicePeriod = this.AudioDevicePeriod.Value
             AudioDeviceBufferLengthMultiplier = this.AudioDeviceBufferLengthMultiplier.Value
             InputCPUSaver = this.InputCPUSaver.Value
-            EnableCursor = false
+            HideCursor = true
             MSAASamples = this.MSAASamples.Value
         }
 

--- a/interlude/src/UI/Screen/Background.fs
+++ b/interlude/src/UI/Screen/Background.fs
@@ -69,7 +69,7 @@ module Background =
                                         else
                                             Content.ThemeConfig.DefaultAccentColor
 
-                            let true_screen_width = fst (Render.viewport_size())
+                            let true_screen_width = fst (Render.framebuffer_size())
 
                             if bmp.Width * 3 / 4 > true_screen_width && true_screen_width > 0 then
                                 bmp.Mutate(fun img -> img.Resize(true_screen_width, 0) |> ignore)

--- a/interlude/src/UI/Screen/Screen.fs
+++ b/interlude/src/UI/Screen/Screen.fs
@@ -209,12 +209,13 @@ module Screen =
 
             if not Toolbar.cursor_hidden || Dialog.exists () then
                 Notifications.display.Draw()
-                let x, y = Mouse.pos ()
+                if Mouse.in_bounds() then
+                    let x, y = Mouse.pos ()
 
-                Render.sprite
-                    (Rect.Box(x, y, Content.ThemeConfig.CursorSize, Content.ThemeConfig.CursorSize))
-                    (Palette.color (255, 1.0f, 0.5f))
-                    (Content.Texture "cursor")
+                    Render.sprite
+                        (Rect.Box(x, y, Content.ThemeConfig.CursorSize, Content.ThemeConfig.CursorSize))
+                        (Palette.color (255, 1.0f, 0.5f))
+                        (Content.Texture "cursor")
 
             perf.Draw()
 


### PR DESCRIPTION
This PR adds letterboxing support to the engine, matching how osu! does it where mouse input is still relative to the entire monitor
All subtle quirks of it seem to be accounted for

Still to do:
- UI for choosing letterboxed mode in system settings

While I'm here I may as well look into some other windowing/engine stuff