### PR TITLE
Online stats, leaderboards and more

### DIFF
--- a/engine/src/Windowing/WindowThread.fs
+++ b/engine/src/Windowing/WindowThread.fs
@@ -197,6 +197,11 @@ module WindowThread =
                 config.FullscreenVideoMode.Height,
                 config.FullscreenVideoMode.RefreshRate
             )
+            GameThread.defer (fun () ->
+                GameThread.framebuffer_resized
+                    (config.FullscreenVideoMode.Width, config.FullscreenVideoMode.Height)
+                    ((config.FullscreenVideoMode.Width, config.FullscreenVideoMode.Height), (0.5f, 0.5f))
+            )
 
         | WindowType.FullscreenLetterbox ->
             let max_width, max_height = GLFW.GetVideoModes(monitor_ptr) |> Array.tryLast |> Option.map (fun vm -> vm.Width, vm.Height) |> Option.defaultValue (1920, 1080)

--- a/interlude/docs/wiki/rulesets.md
+++ b/interlude/docs/wiki/rulesets.md
@@ -7,7 +7,6 @@ folder: Features
 A **ruleset** is a bunch of settings for how scoring works - You can add new rulesets to the game that allow scoring to work differently.
  
 For example, if you are an osu!mania player, you can use an osu!mania ruleset to show the accuracy you would get on osu!mania's engine.  
-Please note that while I've tried to make these simulations as accurate as possible, due to subtle engine differences **the value might be off by up to 0.1%**.
 
 Which I recommend trying out SC, the standard ruleset, some existing simulations of other games are available through the import screen.  
 This lets you see how your scores match up if you've come from other games, or to have different kinds of sessions.  

--- a/interlude/src/Features/Gameplay/ScoreHelpers.fs
+++ b/interlude/src/Features/Gameplay/ScoreHelpers.fs
@@ -30,7 +30,7 @@ module Gameplay =
     let private leaderboard_rank_changed_ev = Event<ScoreInfo>()
     let leaderboard_rank_changed = leaderboard_rank_changed_ev.Publish
 
-    let submit_online_score (score_info: ScoreInfo) =
+    let upload_score (score_info: ScoreInfo) =
         Charts.Scores.Save.post (
             ({
                 ChartId = score_info.ChartMeta.Hash
@@ -94,7 +94,7 @@ module Gameplay =
                     else score_info
 
                 if Network.status = Network.Status.LoggedIn && not standardised_score.IsFailed then
-                    submit_online_score standardised_score
+                    upload_score standardised_score
 
                 let new_bests, improvement_flags =
                     match Map.tryFind Rulesets.current_hash save_data.PersonalBests with

--- a/interlude/src/Features/Gameplay/ScoreHelpers.fs
+++ b/interlude/src/Features/Gameplay/ScoreHelpers.fs
@@ -9,6 +9,7 @@ open Prelude.Gameplay.Replays
 open Prelude.Gameplay.Scoring
 open Prelude.Gameplay
 open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Prelude.Data.Library
 open Interlude.Content
 open Interlude.Options

--- a/interlude/src/Features/LevelSelect/Leaderboard/Leaderboard.fs
+++ b/interlude/src/Features/LevelSelect/Leaderboard/Leaderboard.fs
@@ -40,7 +40,7 @@ module ScoreSync =
                     && OnlineScores.leaderboard_scores.Count < 20
 
                 if leaderboard_has_room then
-                    Gameplay.submit_online_score local_score
+                    Gameplay.upload_score local_score
 
             synced <- true
 

--- a/interlude/src/Features/MainMenu/MainMenu.fs
+++ b/interlude/src/Features/MainMenu/MainMenu.fs
@@ -7,7 +7,7 @@ open Percyqaz.Flux.Graphics
 open Percyqaz.Flux.Windowing
 open Percyqaz.Flux.UI
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Prelude.Data.Library
 open Interlude.Options
 open Interlude
@@ -159,7 +159,7 @@ type MainMenuScreen() as this =
                     %"notification.pattern_cache_started.title",
                     %"notification.pattern_cache_started.body"
                 )
-            if Stats.TOTAL_STATS.NotesHit = 0 then
+            if TOTAL_STATS.NotesHit = 0 then
                 WikiBrowserPage.Show()
 
         splash_text <- choose_splash ()

--- a/interlude/src/Features/Play/Practice/Practice.fs
+++ b/interlude/src/Features/Play/Practice/Practice.fs
@@ -6,7 +6,7 @@ open Percyqaz.Flux.Input
 open Prelude
 open Prelude.Gameplay.Replays
 open Prelude.Gameplay.Scoring
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.Options
 open Interlude.UI
 open Interlude.Content
@@ -52,8 +52,8 @@ module PracticeScreen =
 
             scoring.OnEvent.Add(fun h ->
                 match h.Action with
-                | Hit d when not d.Missed -> Stats.CURRENT_SESSION.NotesHit <- Stats.CURRENT_SESSION.NotesHit + 1
-                | Hold d when not d.Missed -> Stats.CURRENT_SESSION.NotesHit <- Stats.CURRENT_SESSION.NotesHit + 1
+                | Hit d when not d.Missed -> CURRENT_SESSION.NotesHit <- CURRENT_SESSION.NotesHit + 1
+                | Hold d when not d.Missed -> CURRENT_SESSION.NotesHit <- CURRENT_SESSION.NotesHit + 1
                 | _ -> ()
             )
 
@@ -183,7 +183,7 @@ module PracticeScreen =
                     this.State.Scoring.Update chart_time
 
                 if not state.Paused.Value then
-                    Stats.CURRENT_SESSION.PracticeTime <- Stats.CURRENT_SESSION.PracticeTime + elapsed_ms
+                    CURRENT_SESSION.PracticeTime <- CURRENT_SESSION.PracticeTime + elapsed_ms
                     Input.finish_frame_events()
 
                 base.Update(elapsed_ms, moved)

--- a/interlude/src/Features/Printerlude/Printerlude.fs
+++ b/interlude/src/Features/Printerlude/Printerlude.fs
@@ -11,6 +11,7 @@ open Prelude
 open Prelude.Charts
 open Prelude.Data
 open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Prelude.Data.Library
 open Prelude.Gameplay
 open Prelude.Gameplay.Replays
@@ -102,7 +103,7 @@ module Printerlude =
         let challenge_level (io: IOContext) =
             match SelectedChart.CACHE_DATA with
             | Some cc ->
-                let skills = Stats.TOTAL_STATS.KeymodeSkills.[(SelectedChart.keymode() |> int) - 3]
+                let skills = TOTAL_STATS.KeymodeSkills.[(SelectedChart.keymode() |> int) - 3]
                 for p in [ 0.92; 0.93; 0.94; 0.95; 0.96; 0.97; 0.98; 0.99; 1.0 ] do
                     KeymodeSkillBreakdown.what_if cc.Patterns p SelectedChart.rate.Value skills
                     |> sprintf "What if you got %.0f%%: %O" (p * 100.0)

--- a/interlude/src/Features/Score/Score.fs
+++ b/interlude/src/Features/Score/Score.fs
@@ -6,6 +6,7 @@ open Percyqaz.Flux.Graphics
 open Prelude.Gameplay
 open Prelude.Gameplay.Scoring
 open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.Content
 open Interlude.UI
 open Interlude.Features.Gameplay
@@ -98,14 +99,14 @@ type ScoreScreen(score_info: ScoreInfo, results: ImprovementFlags * SessionXPGai
         ScoreScreenHelpers.animation_queue.Add (Animation.Delay 1000.0)
 
         //match xp_gain with
-        //| Some x -> 
+        //| Some x ->
         //    SessionScoreBar(x, Position = Position.SliceRPercent(0.65f).ShrinkT(395.0f).SliceT(40.0f).ShrinkX(40.0f))
         //    |> this.Add
         //| None -> ()
 
         base.Init parent
 
-    override this.Update(elapsed_ms, moved) = 
+    override this.Update(elapsed_ms, moved) =
         ScoreScreenHelpers.animation_queue.Update elapsed_ms
         base.Update(elapsed_ms, moved)
 
@@ -129,7 +130,7 @@ type ScoreScreen(score_info: ScoreInfo, results: ImprovementFlags * SessionXPGai
 
         Render.rect (this.Bounds.ShrinkT(175.0f).SliceT(160.0f).ShrinkT(5.0f)) Colors.shadow_2.O2
         Render.rect (this.Bounds.ShrinkT(175.0f).ShrinkT(160.0f).SliceT(5.0f)) Colors.white
-        
+
         Render.rect (bottom_info.Bounds.ShrinkT 5.0f) (Palette.color (127, 0.5f, 0.0f))
         Render.rect (bottom_info.Bounds.SliceT 5.0f) Colors.white.O2
 

--- a/interlude/src/Features/Score/SessionScore.fs
+++ b/interlude/src/Features/Score/SessionScore.fs
@@ -3,13 +3,13 @@
 open Percyqaz.Flux.Graphics
 open Percyqaz.Flux.UI
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type SessionScoreBar(xp_gain: SessionXPGain) =
     inherit StaticWidget(NodeType.None)
 
-    let xp_now = Stats.CURRENT_SESSION.SessionScore
+    let xp_now = CURRENT_SESSION.SessionScore
     let xp_before = xp_now - xp_gain.Total
 
     let xp_display = Animation.Fade(float32 xp_before)
@@ -38,9 +38,9 @@ type SessionScoreBar(xp_gain: SessionXPGain) =
         base.Init parent
 
     override this.Draw() =
-        let level = int64 xp_display.Value |> Stats.current_level
-        let xp_start = Stats.xp_for_level level |> float32
-        let xp_end = Stats.xp_for_level (level + 1) |> float32
+        let level = int64 xp_display.Value |> current_level
+        let xp_start = xp_for_level level |> float32
+        let xp_end = xp_for_level (level + 1) |> float32
         let xp_progress = (xp_display.Value - xp_start) / (xp_end - xp_start)
 
         // box
@@ -54,7 +54,7 @@ type SessionScoreBar(xp_gain: SessionXPGain) =
         Render.rect (bar.SlicePercentL(xp_progress)) (!*Palette.HIGHLIGHT_100).O4
 
         let counter = this.Bounds.BorderB(60.0f).SliceR(220.0f)
-        let counterq = 
+        let counterq =
             let q = counter.AsQuad
             { q with TopLeft = q.TopLeft - OpenTK.Mathematics.Vector2(30.0f, 0.0f) }
         Render.quad (Quad.translate (10.0f, 10.0f) counterq) Colors.black.AsQuad

--- a/interlude/src/Features/Score/TopBanner.fs
+++ b/interlude/src/Features/Score/TopBanner.fs
@@ -5,6 +5,7 @@ open Percyqaz.Flux.Graphics
 open Percyqaz.Flux.UI
 open Prelude
 open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type TopBanner(score_info: ScoreInfo) as this =
@@ -36,7 +37,7 @@ type TopBanner(score_info: ScoreInfo) as this =
         |* Text(
             match score_info.PlayedBy with
             | ScorePlayedBy.Username p -> K([p] %> "score.played_by")
-            | ScorePlayedBy.You -> (fun () -> [Stats.format_short_time Stats.CURRENT_SESSION.GameTime; Stats.format_short_time Stats.CURRENT_SESSION.PlayTime] %> "score.session_time")
+            | ScorePlayedBy.You -> (fun () -> [format_short_time CURRENT_SESSION.GameTime; format_short_time CURRENT_SESSION.PlayTime] %> "score.session_time")
             , Align = Alignment.RIGHT
             , Position = Position.Row(115.0f, 50.0f).ShrinkX(20.0f)
         )

--- a/interlude/src/Features/Stats/Overall/Overall.fs
+++ b/interlude/src/Features/Stats/Overall/Overall.fs
@@ -3,7 +3,7 @@
 open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type OverallTab() =
@@ -44,16 +44,16 @@ type OverallTab() =
         |+ tabs
         |+ OverallHeader(Position = Position.SliceLPercent(0.4f).ShrinkT(150.0f).SliceT(250.0f).ShrinkX(40.0f))
         |+ OverallTime(
-            (fun () -> Stats.TOTAL_STATS.GameTime + Stats.CURRENT_SESSION.GameTime),
-            (fun () -> Stats.TOTAL_STATS.PlayTime + Stats.CURRENT_SESSION.PlayTime),
-            (fun () -> Stats.TOTAL_STATS.PracticeTime + Stats.CURRENT_SESSION.PracticeTime),
+            (fun () -> TOTAL_STATS.GameTime + CURRENT_SESSION.GameTime),
+            (fun () -> TOTAL_STATS.PlayTime + CURRENT_SESSION.PlayTime),
+            (fun () -> TOTAL_STATS.PracticeTime + CURRENT_SESSION.PracticeTime),
             Position = Position.SliceLPercent(0.4f).ShrinkT(450.0f).SliceT(250.0f).ShrinkX(40.0f)
         )
         |+ PlayCount(
-            (fun () -> Stats.TOTAL_STATS.PlaysStarted + Stats.CURRENT_SESSION.PlaysStarted),
-            (fun () -> Stats.TOTAL_STATS.PlaysCompleted + Stats.CURRENT_SESSION.PlaysCompleted),
-            (fun () -> Stats.TOTAL_STATS.PlaysRetried + Stats.CURRENT_SESSION.PlaysRetried),
-            (fun () -> Stats.TOTAL_STATS.PlaysQuit + Stats.CURRENT_SESSION.PlaysQuit),
+            (fun () -> TOTAL_STATS.PlaysStarted + CURRENT_SESSION.PlaysStarted),
+            (fun () -> TOTAL_STATS.PlaysCompleted + CURRENT_SESSION.PlaysCompleted),
+            (fun () -> TOTAL_STATS.PlaysRetried + CURRENT_SESSION.PlaysRetried),
+            (fun () -> TOTAL_STATS.PlaysQuit + CURRENT_SESSION.PlaysQuit),
             Position = Position.SliceLPercent(0.4f).ShrinkT(750.0f).SliceT(250.0f).ShrinkX(40.0f)
         )
         |* content_panel

--- a/interlude/src/Features/Stats/Overall/OverallHeader.fs
+++ b/interlude/src/Features/Stats/Overall/OverallHeader.fs
@@ -4,16 +4,16 @@ open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Percyqaz.Flux.Graphics
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.Features.Online
 
 type OverallHeader() =
     inherit Container(NodeType.Leaf)
 
-    let xp = Stats.TOTAL_STATS.XP + Stats.CURRENT_SESSION.SessionScore
-    let level = xp |> Stats.current_level
-    let xp_to_next_level = Stats.xp_for_level (level + 1) - Stats.xp_for_level level
-    let current_xp = xp - Stats.xp_for_level level
+    let xp = TOTAL_STATS.XP + CURRENT_SESSION.SessionScore
+    let level = xp |> current_level
+    let xp_to_next_level = xp_for_level (level + 1) - xp_for_level level
+    let current_xp = xp - xp_for_level level
 
     override this.Draw() =
 
@@ -36,7 +36,7 @@ type OverallHeader() =
             Align = Alignment.LEFT
         )
         |+ Text(
-            sprintf "%s: %i" (%"stats.sessions.notes_hit") (Stats.TOTAL_STATS.NotesHit + Stats.CURRENT_SESSION.NotesHit),
+            sprintf "%s: %i" (%"stats.sessions.notes_hit") (TOTAL_STATS.NotesHit + CURRENT_SESSION.NotesHit),
             Color = K Colors.text_subheading,
             Position = Position.SliceT(50.0f).ShrinkT(15.0f).ShrinkX(10.0f),
             Align = Alignment.RIGHT

--- a/interlude/src/Features/Stats/Overall/OverallTime.fs
+++ b/interlude/src/Features/Stats/Overall/OverallTime.fs
@@ -4,7 +4,7 @@ open System
 open Percyqaz.Flux.UI
 open Percyqaz.Flux.Graphics
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type OverallTime(total_time: unit -> float, play_time: unit -> float, practice_time: unit -> float) =
@@ -38,19 +38,19 @@ type OverallTime(total_time: unit -> float, play_time: unit -> float, practice_t
         let practice = practice_time()
         let other = total - play - practice
 
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.total_playtime") (Stats.format_long_time total), content_bounds.SliceT(45.0f).ExpandR(25.0f), Colors.text, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.total_playtime") (format_long_time total), content_bounds.SliceT(45.0f).ExpandR(25.0f), Colors.text, Alignment.LEFT)
 
         let row = content_bounds.ShrinkT(50.0f).SliceT(35.0f)
         Render.rect (row.SliceL(35.0f).Shrink(10.0f)) Colors.cyan_accent
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_ingame") (Stats.format_long_time play), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_ingame") (format_long_time play), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
 
         let row = content_bounds.ShrinkT(90.0f).SliceT(35.0f)
         Render.rect (row.SliceL(35.0f).Shrink(10.0f)) Colors.green_accent
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_practice") (Stats.format_long_time practice), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_practice") (format_long_time practice), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
 
         let row = content_bounds.ShrinkT(130.0f).SliceT(35.0f)
         Render.rect (row.SliceL(35.0f).Shrink(10.0f)) Colors.grey_2
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_other") (Stats.format_long_time other), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_other") (format_long_time other), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
 
     override this.Update(elapsed_ms, moved) =
         base.Update(elapsed_ms, moved)

--- a/interlude/src/Features/Stats/Sessions/Activity.fs
+++ b/interlude/src/Features/Stats/Sessions/Activity.fs
@@ -120,7 +120,7 @@ type RecentActivityGrid(selected: Setting<(DateOnly * Session) option>) =
         )
 
     let today, day_of_week =
-        let today_datetime = Timestamp.now() |> timestamp_to_local_day
+        let today_datetime = Timestamp.now() |> timestamp_to_rg_calendar_day
         DateOnly.FromDateTime(today_datetime), today_datetime.DayOfWeek
 
     let mutable hovered_day = None

--- a/interlude/src/Features/Stats/Sessions/Activity.fs
+++ b/interlude/src/Features/Stats/Sessions/Activity.fs
@@ -6,14 +6,14 @@ open Percyqaz.Flux.UI
 open Percyqaz.Flux.Graphics
 open Percyqaz.Flux.Input
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type YearActivityGrid(year: int, selected: Setting<(DateOnly * Session) option>) =
     inherit StaticWidget(NodeType.Leaf)
 
     let session_dates =
-        Stats.PREVIOUS_SESSIONS
+        PREVIOUS_SESSIONS
         |> Map.filter (fun day _ -> day.Year = year)
         |> Map.map (fun _ sessions ->
             let day_playtime_hours = (sessions |> List.sumBy (_.PlayTime)) / 3600_000.0
@@ -96,7 +96,7 @@ type AllYearsActivityPage(selected: Setting<(DateOnly * Session) option>) =
     override this.Content() =
         let flow = FlowContainer.Vertical<YearActivityGrid>(200.0f, Spacing = 65.0f)
 
-        for year in Stats.PREVIOUS_SESSIONS |> Seq.map (fun kvp -> kvp.Key.Year) |> Seq.distinct |> Seq.sortDescending do
+        for year in PREVIOUS_SESSIONS |> Seq.map (fun kvp -> kvp.Key.Year) |> Seq.distinct |> Seq.sortDescending do
             flow.Add(YearActivityGrid(year, selected |> Setting.trigger(fun _ -> Menu.Back())))
 
         ScrollContainer(flow, Position = Position.ShrinkT(120.0f).ShrinkB(80.0f).SliceX(1380.0f), Margin = 50.0f)
@@ -108,7 +108,7 @@ type RecentActivityGrid(selected: Setting<(DateOnly * Session) option>) =
     inherit Container(NodeType.Leaf)
 
     let session_dates =
-        Stats.PREVIOUS_SESSIONS
+        PREVIOUS_SESSIONS
         |> Map.map (fun _ sessions ->
             let day_playtime_hours = (sessions |> List.sumBy (_.PlayTime)) / 3600_000.0
             let color =

--- a/interlude/src/Features/Stats/Sessions/CurrentSession.fs
+++ b/interlude/src/Features/Stats/Sessions/CurrentSession.fs
@@ -3,12 +3,12 @@
 open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 
 type CurrentSession() =
     inherit Container(NodeType.None)
 
-    let current_session = Stats.CURRENT_SESSION
+    let current_session = CURRENT_SESSION
 
     override this.Init(parent: Widget) =
         this
@@ -17,8 +17,8 @@ type CurrentSession() =
         |+ Text(
             (fun () ->
                 sprintf "%s of playtime over %s, session started at %s"
-                    (Stats.format_short_time current_session.PlayTime)
-                    (Stats.format_short_time current_session.GameTime)
+                    (format_short_time current_session.PlayTime)
+                    (format_short_time current_session.GameTime)
                     ((Timestamp.to_datetime current_session.Start).ToLocalTime().ToShortTimeString())
             ),
             Color = K Colors.text_subheading,

--- a/interlude/src/Features/Stats/Sessions/PreviousSession.fs
+++ b/interlude/src/Features/Stats/Sessions/PreviousSession.fs
@@ -12,7 +12,7 @@ type PreviousSession(session: Session, sessions_today: Session list, close: unit
 
     override this.Init(parent: Widget) =
         this
-        |+ Text(sprintf "Session on %O" ((session.Start |> timestamp_to_local_day).ToShortDateString()), Align = Alignment.LEFT, Position = Position.SliceT 80.0f)
+        |+ Text(sprintf "Session on %O" ((session.Start |> timestamp_to_rg_calendar_day).ToShortDateString()), Align = Alignment.LEFT, Position = Position.SliceT 80.0f)
         |+ Text(
             if session.NotesHit > 0 then
                 sprintf "%s: %i" (%"stats.sessions.notes_hit") session.NotesHit

--- a/interlude/src/Features/Stats/Sessions/PreviousSession.fs
+++ b/interlude/src/Features/Stats/Sessions/PreviousSession.fs
@@ -4,6 +4,7 @@ open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Prelude
 open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type PreviousSession(session: Session, sessions_today: Session list, close: unit -> unit, fd: unit -> unit, bk: unit -> unit) =
@@ -24,8 +25,8 @@ type PreviousSession(session: Session, sessions_today: Session list, close: unit
         |+ Text(
             (fun () ->
                 sprintf "%s of playtime over %s, session started at %s"
-                    (Stats.format_short_time session.PlayTime)
-                    (Stats.format_short_time session.GameTime)
+                    (format_short_time session.PlayTime)
+                    (format_short_time session.GameTime)
                     ((Timestamp.to_datetime session.Start).ToLocalTime().ToShortTimeString())
             ),
             Color = K Colors.text_subheading,

--- a/interlude/src/Features/Stats/Sessions/ScoreList.fs
+++ b/interlude/src/Features/Stats/Sessions/ScoreList.fs
@@ -6,6 +6,7 @@ open Percyqaz.Flux.Graphics
 open Percyqaz.Flux.Input
 open Prelude
 open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Prelude.Data.Library
 open Prelude.Gameplay.Rulesets
 open Interlude.Content
@@ -195,7 +196,7 @@ type ScoreList(start_time: int64, end_time: int64) =
     let scores = FlowContainer.Vertical<Widget>(80.0f, Spacing = 5.0f)
 
     let make_playlist() =
-        let date = timestamp_to_local_day start_time
+        let date = timestamp_to_rg_calendar_day start_time
         CreatePlaylistPage(sprintf "Session on %s" (date.ToShortDateString()), fun (_, collection) ->
             match collection with
             | Playlist p ->

--- a/interlude/src/Features/Stats/Sessions/SessionTime.fs
+++ b/interlude/src/Features/Stats/Sessions/SessionTime.fs
@@ -4,7 +4,7 @@ open System
 open Percyqaz.Flux.UI
 open Percyqaz.Flux.Graphics
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type SessionTime(total_time: unit -> float, play_time: unit -> float, practice_time: unit -> float) =
@@ -38,19 +38,19 @@ type SessionTime(total_time: unit -> float, play_time: unit -> float, practice_t
         let practice = practice_time()
         let other = total - play - practice |> max 0.0
 
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.session_time") (Stats.format_short_time total), content_bounds.SliceT(45.0f), Colors.text, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.session_time") (format_short_time total), content_bounds.SliceT(45.0f), Colors.text, Alignment.LEFT)
 
         let row = content_bounds.ShrinkT(50.0f).SliceT(35.0f)
         Render.rect (row.SliceL(35.0f).Shrink(10.0f)) Colors.cyan_accent
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_ingame") (Stats.format_short_time play), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_ingame") (format_short_time play), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
 
         let row = content_bounds.ShrinkT(90.0f).SliceT(35.0f)
         Render.rect (row.SliceL(35.0f).Shrink(10.0f)) Colors.green_accent
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_practice") (Stats.format_short_time practice), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_practice") (format_short_time practice), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
 
         let row = content_bounds.ShrinkT(130.0f).SliceT(35.0f)
         Render.rect (row.SliceL(35.0f).Shrink(10.0f)) Colors.grey_2
-        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_other") (Stats.format_short_time other), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
+        Text.fill_b(Style.font, sprintf "%s: %s" (%"stats.time_other") (format_short_time other), row.ShrinkL(35.0f), Colors.text_subheading, Alignment.LEFT)
 
     override this.Update(elapsed_ms, moved) =
         base.Update(elapsed_ms, moved)

--- a/interlude/src/Features/Stats/Sessions/Sessions.fs
+++ b/interlude/src/Features/Stats/Sessions/Sessions.fs
@@ -14,7 +14,7 @@ type SessionsTab() =
 
     let session_panel = SwapContainer(CurrentSession(), Position = Position.SliceRPercent(0.6f).ShrinkT(40.0f).ShrinkB(80.0f).ShrinkX(40.0f))
 
-    let TODAY = Timestamp.now() |> timestamp_to_local_day |> DateOnly.FromDateTime
+    let TODAY = Timestamp.now() |> timestamp_to_rg_calendar_day |> DateOnly.FromDateTime
 
     let rec selected_session : Setting<(DateOnly * Session) option> =
         Setting.simple None

--- a/interlude/src/Features/Stats/Sessions/Sessions.fs
+++ b/interlude/src/Features/Stats/Sessions/Sessions.fs
@@ -5,7 +5,7 @@ open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Percyqaz.Flux.Input
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 
 #nowarn "40"
 
@@ -23,7 +23,7 @@ type SessionsTab() =
                 match v with
                 | Some (date, session) ->
                     let sessions_today =
-                        Stats.PREVIOUS_SESSIONS.[date]
+                        PREVIOUS_SESSIONS.[date]
                     PreviousSession(session, sessions_today, (fun () -> selected_session.Set None), cycle_session_fd, cycle_session_bk) :> Widget
                 | None ->
                     CurrentSession()
@@ -32,7 +32,7 @@ type SessionsTab() =
     and cycle_session_fd() =
         match selected_session.Value with
         | Some (date, session) ->
-            let sessions_today = Stats.PREVIOUS_SESSIONS.[date]
+            let sessions_today = PREVIOUS_SESSIONS.[date]
             let i = (List.findIndex (fun s -> s = session) sessions_today)
             if i + 1 < sessions_today.Length then
                 selected_session.Value <- Some (date, sessions_today.[i + 1])
@@ -40,9 +40,9 @@ type SessionsTab() =
                 let mutable date = date.AddDays(1)
                 let mutable found = false
                 while date <= TODAY && not found do
-                    if Stats.PREVIOUS_SESSIONS.ContainsKey date then
+                    if PREVIOUS_SESSIONS.ContainsKey date then
                         found <- true
-                        selected_session.Value <- Some (date, Stats.PREVIOUS_SESSIONS.[date].[0])
+                        selected_session.Value <- Some (date, PREVIOUS_SESSIONS.[date].[0])
                     date <- date.AddDays(1)
                 if not found then
                     selected_session.Value <- None
@@ -50,15 +50,15 @@ type SessionsTab() =
             let mutable date = activity.EarliestVisibleDay
             let mutable found = false
             while date <= TODAY && not found do
-                if Stats.PREVIOUS_SESSIONS.ContainsKey date then
+                if PREVIOUS_SESSIONS.ContainsKey date then
                     found <- true
-                    selected_session.Value <- Some (date, Stats.PREVIOUS_SESSIONS.[date].[0])
+                    selected_session.Value <- Some (date, PREVIOUS_SESSIONS.[date].[0])
                 date <- date.AddDays(1)
 
     and cycle_session_bk() =
         match selected_session.Value with
         | Some (date, session) ->
-            let sessions_today = Stats.PREVIOUS_SESSIONS.[date]
+            let sessions_today = PREVIOUS_SESSIONS.[date]
             let i = (List.findIndex (fun s -> s = session) sessions_today)
             if i > 0 then
                 selected_session.Value <- Some (date, sessions_today.[i - 1])
@@ -67,9 +67,9 @@ type SessionsTab() =
                 let mutable found = false
                 let earliest_day = activity.EarliestVisibleDay
                 while date >= earliest_day && not found do
-                    if Stats.PREVIOUS_SESSIONS.ContainsKey date then
+                    if PREVIOUS_SESSIONS.ContainsKey date then
                         found <- true
-                        selected_session.Value <- Some (date, List.last Stats.PREVIOUS_SESSIONS.[date])
+                        selected_session.Value <- Some (date, List.last PREVIOUS_SESSIONS.[date])
                     date <- date.AddDays(-1)
                 if not found then
                     selected_session.Value <- None
@@ -78,9 +78,9 @@ type SessionsTab() =
             let mutable found = false
             let earliest_day = activity.EarliestVisibleDay
             while date >= earliest_day && not found do
-                if Stats.PREVIOUS_SESSIONS.ContainsKey date then
+                if PREVIOUS_SESSIONS.ContainsKey date then
                     found <- true
-                    selected_session.Value <- Some (date,  List.last Stats.PREVIOUS_SESSIONS.[date])
+                    selected_session.Value <- Some (date,  List.last PREVIOUS_SESSIONS.[date])
                 date <- date.AddDays(-1)
 
     and activity : RecentActivityGrid =
@@ -94,17 +94,17 @@ type SessionsTab() =
         |+ SessionTime(
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.GameTime
+                | None -> CURRENT_SESSION.GameTime
                 | Some (_, a) -> a.GameTime
             ),
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.PlayTime
+                | None -> CURRENT_SESSION.PlayTime
                 | Some (_, a) -> a.PlayTime
             ),
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.PracticeTime
+                | None -> CURRENT_SESSION.PracticeTime
                 | Some (_, a) -> a.PracticeTime
             ),
             Position = Position.SliceLPercent(0.4f).ShrinkT(450.0f).SliceT(250.0f).ShrinkX(40.0f))
@@ -112,22 +112,22 @@ type SessionsTab() =
         |+ PlayCount(
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.PlaysStarted
+                | None -> CURRENT_SESSION.PlaysStarted
                 | Some (_, a) -> a.PlaysStarted
             ),
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.PlaysCompleted
+                | None -> CURRENT_SESSION.PlaysCompleted
                 | Some (_, a) -> a.PlaysCompleted
             ),
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.PlaysRetried
+                | None -> CURRENT_SESSION.PlaysRetried
                 | Some (_, a) -> a.PlaysRetried
             ),
             (fun () ->
                 match selected_session.Value with
-                | None -> Stats.CURRENT_SESSION.PlaysQuit
+                | None -> CURRENT_SESSION.PlaysQuit
                 | Some (_, a) -> a.PlaysQuit
             ),
             Position = Position.SliceLPercent(0.4f).ShrinkT(750.0f).SliceT(250.0f).ShrinkX(40.0f))
@@ -146,4 +146,4 @@ type SessionsTab() =
                 cycle_session_fd()
 
     member this.ShowSessionForDate(date: DateOnly) =
-        selected_session.Value <- Some (date, Stats.PREVIOUS_SESSIONS.[date].[0])
+        selected_session.Value <- Some (date, PREVIOUS_SESSIONS.[date].[0])

--- a/interlude/src/Features/Stats/Skillsets/Breakdown.fs
+++ b/interlude/src/Features/Stats/Skillsets/Breakdown.fs
@@ -3,7 +3,7 @@
 open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Prelude.Gameplay
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Prelude.Charts.Processing.Patterns
 open Interlude.UI
 
@@ -22,7 +22,7 @@ type SkillBreakdown() =
         let available_keymodes =
             seq {
                 for i = 3 to 10 do
-                    if Stats.TOTAL_STATS.KeymodeSkills.[i - 3] <> KeymodeSkillBreakdown.Default then
+                    if TOTAL_STATS.KeymodeSkills.[i - 3] <> KeymodeSkillBreakdown.Default then
                         yield i
             }
             |> Array.ofSeq

--- a/interlude/src/Features/Stats/Skillsets/BreakdownGraph.fs
+++ b/interlude/src/Features/Stats/Skillsets/BreakdownGraph.fs
@@ -5,7 +5,7 @@ open Percyqaz.Flux.Input
 open Percyqaz.Flux.UI
 open Prelude
 open Prelude.Gameplay
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Prelude.Charts.Processing.Patterns
 open Interlude.UI
 open Interlude.Content
@@ -161,9 +161,9 @@ type SkillBreakdownGraph(pattern_type: CorePattern, source: GraphSource, data: P
     static member Create(keymode: int, pattern_type: CorePattern, source: GraphSource) =
         let keymode_info =
             match source with
-            | AllTime -> Stats.TOTAL_STATS.KeymodeSkills.[keymode - 3]
-            | Recent -> Stats.CURRENT_SESSION.KeymodeSkills.[keymode - 3]
-            | Session -> Stats.CURRENT_SESSION.KeymodeSkills.[keymode - 3]
+            | AllTime -> TOTAL_STATS.KeymodeSkills.[keymode - 3]
+            | Recent -> CURRENT_SESSION.KeymodeSkills.[keymode - 3]
+            | Session -> CURRENT_SESSION.KeymodeSkills.[keymode - 3]
         let data =
             match pattern_type with
             | Jacks -> keymode_info.Jacks

--- a/interlude/src/Features/Stats/Skillsets/Overview.fs
+++ b/interlude/src/Features/Stats/Skillsets/Overview.fs
@@ -5,14 +5,14 @@ open Percyqaz.Flux.UI
 open Prelude
 open Prelude.Charts.Processing.Patterns
 open Prelude.Gameplay
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type KeymodeOverview(keymode: int, button_callback: GraphSource -> CorePattern option -> unit) =
     inherit Container(NodeType.None)
 
-    let all_time = Stats.TOTAL_STATS.KeymodeSkills.[keymode - 3].Tiny
-    let recent = Stats.CURRENT_SESSION.KeymodeSkills.[keymode - 3].Tiny
+    let all_time = TOTAL_STATS.KeymodeSkills.[keymode - 3].Tiny
+    let recent = CURRENT_SESSION.KeymodeSkills.[keymode - 3].Tiny
 
     let bar (value: float32) (max_value: float32) (color: Color * Color) (pos: Position) =
         { new StaticWidget(NodeType.None, Position = pos) with
@@ -58,7 +58,7 @@ type Overview(button_callback: int -> GraphSource -> CorePattern option -> unit)
     override this.Init(parent) =
         let container = FlowContainer.Vertical<KeymodeOverview>(150.0f, Spacing = 50.0f)
         for i = 3 to 10 do
-            if Stats.TOTAL_STATS.KeymodeSkills.[i - 3] <> KeymodeSkillBreakdown.Default then
+            if TOTAL_STATS.KeymodeSkills.[i - 3] <> KeymodeSkillBreakdown.Default then
                 container.Add(KeymodeOverview(i, button_callback i))
         if container.Count = 0 then
             this

--- a/interlude/src/Features/Stats/Skillsets/Timeline.fs
+++ b/interlude/src/Features/Stats/Skillsets/Timeline.fs
@@ -3,7 +3,7 @@
 open Percyqaz.Common
 open Percyqaz.Flux.UI
 open Prelude.Gameplay
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.UI
 
 type SkillTimeline() =
@@ -22,7 +22,7 @@ type SkillTimeline() =
         let available_keymodes =
             seq {
                 for i = 3 to 10 do
-                    if Stats.TOTAL_STATS.KeymodeSkills.[i - 3] <> KeymodeSkillBreakdown.Default then
+                    if TOTAL_STATS.KeymodeSkills.[i - 3] <> KeymodeSkillBreakdown.Default then
                         yield i
             }
             |> Array.ofSeq

--- a/interlude/src/Features/Stats/Skillsets/TimelineGraph.fs
+++ b/interlude/src/Features/Stats/Skillsets/TimelineGraph.fs
@@ -28,7 +28,7 @@ type SkillTimelineGraph(keymode: int, day_range: Animation.Fade, day_offset: Ani
     let all_time_records = TOTAL_STATS.KeymodeSkills.[keymode - 3].Tiny
     let all_time_max = Array.max [|all_time_records.Jacks; all_time_records.Chordstream; all_time_records.Stream|]
 
-    let TODAY = Timestamp.now() |> timestamp_to_local_day |> DateOnly.FromDateTime
+    let TODAY = Timestamp.now() |> timestamp_to_rg_calendar_day |> DateOnly.FromDateTime
 
     let sessions =
         PREVIOUS_SESSIONS.Keys

--- a/interlude/src/Features/Stats/Skillsets/TimelineGraph.fs
+++ b/interlude/src/Features/Stats/Skillsets/TimelineGraph.fs
@@ -8,7 +8,7 @@ open Percyqaz.Flux.Input
 open Prelude
 open Prelude.Charts.Processing.Patterns
 open Prelude.Gameplay
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 
 [<Struct>]
 type private GraphDataPoint =
@@ -25,15 +25,15 @@ module SkillTimelineGraph =
 type SkillTimelineGraph(keymode: int, day_range: Animation.Fade, day_offset: Animation.Fade) =
     inherit StaticWidget(NodeType.None)
 
-    let all_time_records = Stats.TOTAL_STATS.KeymodeSkills.[keymode - 3].Tiny
+    let all_time_records = TOTAL_STATS.KeymodeSkills.[keymode - 3].Tiny
     let all_time_max = Array.max [|all_time_records.Jacks; all_time_records.Chordstream; all_time_records.Stream|]
 
     let TODAY = Timestamp.now() |> timestamp_to_local_day |> DateOnly.FromDateTime
 
     let sessions =
-        Stats.PREVIOUS_SESSIONS.Keys
+        PREVIOUS_SESSIONS.Keys
         |> Seq.sortDescending
-        |> Seq.map (fun k -> k, TODAY.DayNumber - k.DayNumber, Map.find k Stats.PREVIOUS_SESSIONS)
+        |> Seq.map (fun k -> k, TODAY.DayNumber - k.DayNumber, Map.find k PREVIOUS_SESSIONS)
         |> Array.ofSeq
 
     let timeline_end =

--- a/interlude/src/Features/Stats/Sync.fs
+++ b/interlude/src/Features/Stats/Sync.fs
@@ -1,0 +1,40 @@
+﻿namespace Interlude.Features.Stats
+
+open Percyqaz.Common
+open Percyqaz.Flux.Windowing
+open Prelude.Data.User.Stats
+open Interlude.Web.Shared.Requests
+open Interlude.Features.Online
+open Interlude.Features.Gameplay
+
+module StatsSync =
+
+    let upload_online_stats () =
+        if Network.status = Network.LoggedIn then
+            match StatsSyncUpstream.Create () with
+            | None -> ()
+            | Some upstream_data ->
+                Stats.Sync.post (
+                    (upstream_data),
+                    (function
+                        | Some true -> ()
+                        | Some false -> Logging.Error "Error submitting stats (Server indicated error)"
+                        | None -> Logging.Error "Error submitting stats"
+                    )
+                )
+
+    let sync_online_stats () =
+        Stats.Fetch.get
+            (function
+                | Some data ->
+                    GameThread.defer (fun () ->
+                        if data.Accept then
+                            Logging.Debug "Syncing stats with online server ...";
+                            upload_online_stats ()
+                    )
+                | None -> Logging.Error "Error fetching online stats"
+            )
+
+    let init_startup () =
+        Gameplay.score_saved.Add (fun _ -> upload_online_stats())
+        NetworkEvents.successful_login.Add (fun _ -> sync_online_stats())

--- a/interlude/src/Features/Toolbar/Toolbar.fs
+++ b/interlude/src/Features/Toolbar/Toolbar.fs
@@ -5,7 +5,7 @@ open Percyqaz.Flux.Audio
 open Percyqaz.Flux.Input
 open Percyqaz.Flux.UI
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.Content
 open Interlude.UI
 open Interlude
@@ -166,7 +166,7 @@ type Toolbar() =
             Terminal.draw ()
 
     override this.Update(elapsed_ms, moved) =
-        Stats.CURRENT_SESSION.GameTime <- Stats.CURRENT_SESSION.GameTime + elapsed_ms
+        CURRENT_SESSION.GameTime <- CURRENT_SESSION.GameTime + elapsed_ms
 
         let moved =
             if Toolbar.was_hidden <> Toolbar.hidden then

--- a/interlude/src/Interlude.fsproj
+++ b/interlude/src/Interlude.fsproj
@@ -134,6 +134,7 @@
     <Compile Include="Features\Mounts\Edit.fs" />
     <Compile Include="Features\Mounts\Display.fs" />
     <Compile Include="Features\Mounts\Mounts.fs" />
+    <Compile Include="Features\Stats\Sync.fs" />
     <Compile Include="Features\Stats\Tables.fs" />
     <Compile Include="Features\Stats\PlayCount.fs" />
     <Compile Include="Features\Stats\Skillsets\BreakdownGraph.fs" />

--- a/interlude/src/Resources/MenuSplashes.txt
+++ b/interlude/src/Resources/MenuSplashes.txt
@@ -422,3 +422,5 @@ Is this the way you find out?
 Dance with the one that brought you
 No more time, no more kill my vibe
 all this fuss over nothing
+you make me say wow, wow, wow, wow
+Feel the vibe and groove

--- a/interlude/src/Startup.fs
+++ b/interlude/src/Startup.fs
@@ -3,11 +3,9 @@
 open Percyqaz.Common
 open Percyqaz.Flux.Audio
 open Prelude
-open Prelude.Data.User
+open Prelude.Data.User.Stats
 open Interlude.Options
 open Interlude.Content
-open Interlude.Features.Import
-open Interlude.Features.Import.osu
 open Interlude.Features.Gameplay
 open Interlude.Features.MainMenu
 open Interlude.Features.Mounts
@@ -16,13 +14,13 @@ open Interlude.Features.Multiplayer
 open Interlude.Features.Printerlude
 open Interlude.Features.Toolbar
 open Interlude.Features.Online
-open Interlude.Features.Score
 
 module Startup =
 
     let mutable private deinit_required = false
     let mutable private deinit_once = false
 
+    // todo: combine these steps as they are now serialised
     let init_startup (instance) =
         Options.init_startup ()
         Content.init_startup ()

--- a/interlude/src/Startup.fs
+++ b/interlude/src/Startup.fs
@@ -14,6 +14,7 @@ open Interlude.Features.Multiplayer
 open Interlude.Features.Printerlude
 open Interlude.Features.Toolbar
 open Interlude.Features.Online
+open Interlude.Features.Stats
 
 module Startup =
 
@@ -25,6 +26,7 @@ module Startup =
         Options.init_startup ()
         Content.init_startup ()
         Stats.init_startup Content.Library Content.UserData
+        StatsSync.init_startup ()
 
     let init_window (instance) =
         Screen.init_window

--- a/online/server/API/API.fs
+++ b/online/server/API/API.fs
@@ -55,6 +55,8 @@ module API =
 
         add_endpoint Stats.Sync.ROUTE Stats.Sync.handle
         add_endpoint Stats.Fetch.ROUTE Stats.Fetch.handle
+        add_endpoint Stats.Leaderboard.XP.ROUTE Stats.Leaderboard.XP.handle
+        add_endpoint Stats.Leaderboard.MonthlyXP.ROUTE Stats.Leaderboard.MonthlyXP.handle
 
     let handle_request
         (

--- a/online/server/API/API.fs
+++ b/online/server/API/API.fs
@@ -53,6 +53,9 @@ module API =
         add_endpoint Friends.Add.ROUTE Friends.Add.handle
         add_endpoint Friends.Remove.ROUTE Friends.Remove.handle
 
+        add_endpoint Stats.Sync.ROUTE Stats.Sync.handle
+        add_endpoint Stats.Fetch.ROUTE Stats.Fetch.handle
+
     let handle_request
         (
             method: HttpMethod,

--- a/online/server/API/Stats/Fetch.fs
+++ b/online/server/API/Stats/Fetch.fs
@@ -1,0 +1,36 @@
+﻿namespace Interlude.Web.Server.API.Stats
+
+open NetCoreServer
+open Interlude.Web.Shared.Requests
+open Interlude.Web.Server.API
+open Interlude.Web.Server.Domain.Core
+open Interlude.Web.Server.Domain.Services
+
+module Fetch =
+
+    open Stats.Fetch
+
+    let handle
+        (
+            body: string,
+            query_params: Map<string, string array>,
+            headers: Map<string, string>,
+            response: HttpResponse
+        ) =
+        async {
+            let user_id, _ = authorize headers
+
+            let stats = Stats.get_or_default user_id
+            let data: Response =
+                {
+                    NetworkId = user_id
+                    PlayTime = stats.Playtime
+                    PracticeTime = stats.PracticeTime
+                    GameTime = stats.GameTime
+                    NotesHit = stats.NotesHit
+                    XP = stats.XP
+                    KeymodePlaytime = Map.ofSeq [4, stats._4KPlaytime; 7, stats._7KPlaytime; 10, stats._10KPlaytime]
+                }
+
+            response.ReplyJson(data)
+        }

--- a/online/server/API/Stats/Leaderboard/MonthlyXP.fs
+++ b/online/server/API/Stats/Leaderboard/MonthlyXP.fs
@@ -1,0 +1,50 @@
+﻿namespace Interlude.Web.Server.API.Stats.Leaderboard
+
+open NetCoreServer
+open Percyqaz.Common
+open Prelude.Data.User.Stats
+open Interlude.Web.Shared.Requests
+open Interlude.Web.Server.API
+open Interlude.Web.Server.Domain.Core
+
+module MonthlyXP =
+
+    open Stats.Leaderboard.MonthlyXP
+
+    let handle
+        (
+            body: string,
+            query_params: Map<string, string array>,
+            headers: Map<string, string>,
+            response: HttpResponse
+        ) =
+        async {
+            let _, _ = authorize headers
+
+            let by_playtime = query_params.TryFind "sort" |> Option.bind Array.tryHead = Some "playtime"
+
+            let month = Timestamp.now() |> timestamp_to_leaderboard_month
+
+            let data =
+                if by_playtime then
+                    MonthlyStats.playtime_leaderboard month
+                else
+                    MonthlyStats.xp_leaderboard month
+
+            let users =
+                data |> Array.map (fun x -> x.UserId) |> User.by_ids |> Map.ofArray
+
+            let result =
+                data
+                |> Array.map (fun l ->
+                    let user = users.[l.UserId]
+                    {
+                        Username = user.Username
+                        Color = user.Color
+                        XP = l.XP
+                        Playtime = l.Playtime
+                    }
+                )
+
+            response.ReplyJson(result: Response)
+        }

--- a/online/server/API/Stats/Leaderboard/XP.fs
+++ b/online/server/API/Stats/Leaderboard/XP.fs
@@ -1,0 +1,46 @@
+﻿namespace Interlude.Web.Server.API.Stats.Leaderboard
+
+open NetCoreServer
+open Interlude.Web.Shared.Requests
+open Interlude.Web.Server.API
+open Interlude.Web.Server.Domain.Core
+
+module XP =
+
+    open Stats.Leaderboard.XP
+
+    let handle
+        (
+            body: string,
+            query_params: Map<string, string array>,
+            headers: Map<string, string>,
+            response: HttpResponse
+        ) =
+        async {
+            let _, _ = authorize headers
+
+            let by_playtime = query_params.TryFind "sort" |> Option.bind Array.tryHead = Some "playtime"
+
+            let data =
+                if by_playtime then
+                    Stats.playtime_leaderboard ()
+                else
+                    Stats.xp_leaderboard ()
+
+            let users =
+                data |> Array.map (fun x -> x.UserId) |> User.by_ids |> Map.ofArray
+
+            let result =
+                data
+                |> Array.map (fun l ->
+                    let user = users.[l.UserId]
+                    {
+                        Username = user.Username
+                        Color = user.Color
+                        XP = l.XP
+                        Playtime = l.Playtime
+                    }
+                )
+
+            response.ReplyJson(result: Response)
+        }

--- a/online/server/API/Stats/Sync.fs
+++ b/online/server/API/Stats/Sync.fs
@@ -1,0 +1,33 @@
+﻿namespace Interlude.Web.Server.API.Stats
+
+open NetCoreServer
+open Percyqaz.Common
+open Prelude
+open Interlude.Web.Shared.Requests
+open Interlude.Web.Server.API
+open Interlude.Web.Server.Domain.Services
+
+module Sync =
+
+    open Stats.Sync
+
+    let handle
+        (
+            body: string,
+            query_params: Map<string, string array>,
+            headers: Map<string, string>,
+            response: HttpResponse
+        ) =
+        async {
+            let user_id, user = authorize headers
+
+            match JSON.FromString body with
+            | Error e -> raise (BadRequestException None)
+            | Ok(request: Request) ->
+
+            match Stats.sync user_id request with
+            | Ok() -> response.ReplyJson(true)
+            | Error reason ->
+                Logging.Error "Error syncing stats for user #%i '%s': %s" user_id user.Username reason
+                response.ReplyJson(false)
+        }

--- a/online/server/Domain/Core/Scores.fs
+++ b/online/server/Domain/Core/Scores.fs
@@ -221,7 +221,7 @@ module Score =
             WITH UserBestScores AS (
                 SELECT
                     UserId, TimePlayed, Rate, Mods, Accuracy, Grade, Lamp, ReplayId,
-                    ROW_NUMBER() OVER (PARTITION BY UserId ORDER BY Accuracy DESC) AS UserScoreRank
+                    ROW_NUMBER() OVER (PARTITION BY UserId ORDER BY Accuracy DESC, TimePlayed ASC) AS UserScoreRank
                 FROM scores2
                 WHERE ChartId = @ChartId AND Ranked = 1
             )

--- a/online/server/Domain/Core/Stats.fs
+++ b/online/server/Domain/Core/Stats.fs
@@ -1,0 +1,174 @@
+﻿namespace Interlude.Web.Server.Domain.Core
+
+open Percyqaz.Common
+open Percyqaz.Data.Sqlite
+open Prelude.Gameplay
+open Interlude.Web.Server
+
+type Stats =
+    {
+        LastSync: int64
+        XP: int64
+        Playtime: float
+        _4K: KeymodeTinyBreakdown
+        _7K: KeymodeTinyBreakdown
+        _10K: KeymodeTinyBreakdown
+    }
+    static member Default =
+        {
+            LastSync = 0L
+            XP = 0L
+            Playtime = 0.0
+            _4K = KeymodeTinyBreakdown.Default
+            _7K = KeymodeTinyBreakdown.Default
+            _10K = KeymodeTinyBreakdown.Default
+        }
+
+module Stats =
+
+    let private DEFAULT = Stats.Default
+
+    let internal CREATE_TABLE: NonQuery<unit> =
+        { NonQuery.without_parameters () with
+            SQL =
+                """
+            CREATE TABLE stats (
+                UserId INTEGER PRIMARY KEY NOT NULL,
+                LastSync INTEGER NOT NULL,
+                XP FLOAT NOT NULL,
+                Playtime FLOAT NOT NULL,
+
+                _4KCombined FLOAT NOT NULL,
+                _4KJacks FLOAT NOT NULL,
+                _4KChordstream FLOAT NOT NULL,
+                _4KStream FLOAT NOT NULL,
+
+                _7KCombined FLOAT NOT NULL,
+                _7KJacks FLOAT NOT NULL,
+                _7KChordstream FLOAT NOT NULL,
+                _7KStream FLOAT NOT NULL,
+
+                _10KCombined FLOAT NOT NULL,
+                _10KJacks FLOAT NOT NULL,
+                _10KChordstream FLOAT NOT NULL,
+                _10KStream FLOAT NOT NULL,
+                FOREIGN KEY (UserId) REFERENCES users(Id) ON DELETE CASCADE
+            );
+            """
+        }
+
+    let private GET: Query<int64, Stats> =
+        {
+            SQL =
+                """
+            SELECT
+                LastSync, XP, Playtime,
+                _4KCombined, _4KJacks, _4KChordstream, _4KStream,
+                _7KCombined, _7KJacks, _7KChordstream, _7KStream,
+                _10KCombined, _10KJacks, _10KChordstream, _10KStream
+            FROM stats
+            WHERE UserId = @UserId;
+            """
+            Parameters = [ "@UserId", SqliteType.Integer, 8 ]
+            FillParameters = fun p user_id -> p.Int64 user_id
+            Read = fun r ->
+                {
+                    LastSync = r.Int64
+                    XP = r.Int64
+                    Playtime = r.Float64
+                    _4K = { Combined = r.Float32; Jacks = r.Float32; Chordstream = r.Float32; Stream = r.Float32 }
+                    _7K = { Combined = r.Float32; Jacks = r.Float32; Chordstream = r.Float32; Stream = r.Float32 }
+                    _10K = { Combined = r.Float32; Jacks = r.Float32; Chordstream = r.Float32; Stream = r.Float32 }
+                }
+        }
+
+    let get (user_id: int64) =
+        GET.Execute (user_id) core_db |> expect |> Array.tryExactlyOne
+
+    let get_or_default (user_id: int) =
+        GET.Execute user_id core_db |> expect |> Array.tryExactlyOne |> Option.defaultValue DEFAULT
+
+    let private SET: NonQuery<int64 * Stats> =
+        {
+            SQL =
+                """
+            INSERT OR REPLACE INTO stats (
+                UserId, LastSync, XP, Playtime,
+                _4KCombined, _4KJacks, _4KChordstream, _4KStream,
+                _7KCombined, _7KJacks, _7KChordstream, _7KStream,
+                _10KCombined, _10KJacks, _10KChordstream, _10KStream
+            )
+            VALUES (
+                @UserId, @LastSync, @XP, @Playtime,
+                @_4KCombined, @_4KJacks, @_4KChordstream, @_4KStream,
+                @_7KCombined, @_7KJacks, @_7KChordstream, @_7KStream,
+                @_10KCombined, @_10KJacks, @_10KChordstream, @_10KStream,
+            );
+            """
+            Parameters =
+                [
+                    "@UserId", SqliteType.Integer, 8
+                    "@LastSync", SqliteType.Integer, 8
+                    "@XP", SqliteType.Integer, 8
+                    "@Playtime", SqliteType.Real, 8
+
+                    "@_4KCombined", SqliteType.Real, 4
+                    "@_4KJacks", SqliteType.Real, 4
+                    "@_4KChordstream", SqliteType.Real, 4
+                    "@_4KStream", SqliteType.Real, 4
+
+                    "@_7KCombined", SqliteType.Real, 4
+                    "@_7KJacks", SqliteType.Real, 4
+                    "@_7KChordstream", SqliteType.Real, 4
+                    "@_7KStream", SqliteType.Real, 4
+
+                    "@_10KCombined", SqliteType.Real, 4
+                    "@_10KJacks", SqliteType.Real, 4
+                    "@_10KChordstream", SqliteType.Real, 4
+                    "@_10KStream", SqliteType.Real, 4
+                ]
+            FillParameters =
+                (fun p (user_id, stats) ->
+                    p.Int64 user_id
+                    p.Int64 stats.LastSync
+                    p.Int64 stats.XP
+                    p.Float64 stats.Playtime
+
+                    p.Float32 stats._4K.Combined
+                    p.Float32 stats._4K.Jacks
+                    p.Float32 stats._4K.Chordstream
+                    p.Float32 stats._4K.Stream
+
+                    p.Float32 stats._7K.Combined
+                    p.Float32 stats._7K.Jacks
+                    p.Float32 stats._7K.Chordstream
+                    p.Float32 stats._7K.Stream
+
+                    p.Float32 stats._10K.Combined
+                    p.Float32 stats._10K.Jacks
+                    p.Float32 stats._10K.Chordstream
+                    p.Float32 stats._10K.Stream
+                )
+        }
+
+    let set (user_id: int64) (stats: Stats) =
+        SET.Execute (user_id, stats) core_db |> expect |> ignore
+
+    type TableLeaderboardModel = { UserId: int64; Rating: float }
+
+    let private LEADERBOARD: Query<string, TableLeaderboardModel> =
+        {
+            SQL =
+                """
+            SELECT UserId, Rating FROM table_ratings
+            WHERE TableId = @TableId
+            ORDER BY Rating DESC
+            LIMIT 50;
+            """
+            Parameters = [ "@TableId", SqliteType.Text, -1 ]
+            FillParameters = fun p table_id -> p.String table_id
+            Read = (fun r -> { UserId = r.Int64; Rating = r.Float64 })
+        }
+
+    let leaderboard (table_id: string) =
+        LEADERBOARD.Execute table_id core_db |> expect

--- a/online/server/Domain/Core/Stats.fs
+++ b/online/server/Domain/Core/Stats.fs
@@ -207,6 +207,20 @@ module Stats =
     let xp_leaderboard () =
         XP_LEADERBOARD.Execute () core_db |> expect
 
+    let private PLAYTIME_LEADERBOARD: Query<unit, XPLeaderboardModel> =
+        { Query.without_parameters() with
+            SQL =
+                """
+            SELECT UserId, XP, Playtime FROM stats
+            ORDER BY Playtime DESC
+            LIMIT 50;
+            """
+            Read = (fun r -> { UserId = r.Int64; XP = r.Int64; Playtime = r.Float64 })
+        }
+
+    let playtime_leaderboard () =
+        PLAYTIME_LEADERBOARD.Execute () core_db |> expect
+
     type KeymodeLeaderboardModel =
         {
             UserId: int64
@@ -453,6 +467,23 @@ module MonthlyStats =
 
     let xp_leaderboard (month: int) =
         XP_LEADERBOARD.Execute month core_db |> expect
+
+    let private PLAYTIME_LEADERBOARD: Query<int, XPLeaderboardModel> =
+        {
+            SQL =
+                """
+            SELECT UserId, XP, Playtime FROM monthly_stats
+            WHERE Month = @Month
+            ORDER BY Playtime DESC
+            LIMIT 50;
+            """
+            Parameters = [ "@Month", SqliteType.Integer, 4 ]
+            FillParameters = fun p month -> p.Int32 month
+            Read = (fun r -> { UserId = r.Int64; XP = r.Int64; Playtime = r.Float64 })
+        }
+
+    let playtime_leaderboard (month: int) =
+        PLAYTIME_LEADERBOARD.Execute month core_db |> expect
 
     type KeymodeLeaderboardModel =
         {

--- a/online/server/Domain/Core/Stats.fs
+++ b/online/server/Domain/Core/Stats.fs
@@ -8,19 +8,32 @@ open Interlude.Web.Server
 type Stats =
     {
         LastSync: int64
-        XP: int64
         Playtime: float
+        PracticeTime: float
+        GameTime: float
+        NotesHit: int
+        XP: int64
+
+        _4KPlaytime: float
         _4K: KeymodeTinyBreakdown
+        _7KPlaytime: float
         _7K: KeymodeTinyBreakdown
+        _10KPlaytime: float
         _10K: KeymodeTinyBreakdown
     }
     static member Default =
         {
             LastSync = 0L
-            XP = 0L
             Playtime = 0.0
+            PracticeTime = 0.0
+            GameTime = 0.0
+            NotesHit = 0
+            XP = 0L
+            _4KPlaytime = 0.0
             _4K = KeymodeTinyBreakdown.Default
+            _7KPlaytime = 0.0
             _7K = KeymodeTinyBreakdown.Default
+            _10KPlaytime = 0.0
             _10K = KeymodeTinyBreakdown.Default
         }
 
@@ -35,19 +48,25 @@ module Stats =
             CREATE TABLE stats (
                 UserId INTEGER PRIMARY KEY NOT NULL,
                 LastSync INTEGER NOT NULL,
-                XP FLOAT NOT NULL,
                 Playtime FLOAT NOT NULL,
+                PracticeTime FLOAT NOT NULL,
+                GameTime FLOAT NOT NULL,
+                NotesHit INTEGER NOT NULL,
+                XP FLOAT NOT NULL,
 
+                _4KPlaytime FLOAT NOT NULL,
                 _4KCombined FLOAT NOT NULL,
                 _4KJacks FLOAT NOT NULL,
                 _4KChordstream FLOAT NOT NULL,
                 _4KStream FLOAT NOT NULL,
 
+                _7KPlaytime FLOAT NOT NULL,
                 _7KCombined FLOAT NOT NULL,
                 _7KJacks FLOAT NOT NULL,
                 _7KChordstream FLOAT NOT NULL,
                 _7KStream FLOAT NOT NULL,
 
+                _10KPlaytime FLOAT NOT NULL,
                 _10KCombined FLOAT NOT NULL,
                 _10KJacks FLOAT NOT NULL,
                 _10KChordstream FLOAT NOT NULL,
@@ -62,10 +81,10 @@ module Stats =
             SQL =
                 """
             SELECT
-                LastSync, XP, Playtime,
-                _4KCombined, _4KJacks, _4KChordstream, _4KStream,
-                _7KCombined, _7KJacks, _7KChordstream, _7KStream,
-                _10KCombined, _10KJacks, _10KChordstream, _10KStream
+                LastSync, Playtime, PracticeTime, GameTime, NotesHit, XP,
+                _4KPlaytime, _4KCombined, _4KJacks, _4KChordstream, _4KStream,
+                _7KPlaytime, _7KCombined, _7KJacks, _7KChordstream, _7KStream,
+                _10KPlaytime, _10KCombined, _10KJacks, _10KChordstream, _10KStream
             FROM stats
             WHERE UserId = @UserId;
             """
@@ -74,18 +93,24 @@ module Stats =
             Read = fun r ->
                 {
                     LastSync = r.Int64
-                    XP = r.Int64
                     Playtime = r.Float64
+                    PracticeTime = r.Float64
+                    GameTime = r.Float64
+                    NotesHit = r.Int32
+                    XP = r.Int64
+                    _4KPlaytime = r.Float64
                     _4K = { Combined = r.Float32; Jacks = r.Float32; Chordstream = r.Float32; Stream = r.Float32 }
+                    _7KPlaytime = r.Float64
                     _7K = { Combined = r.Float32; Jacks = r.Float32; Chordstream = r.Float32; Stream = r.Float32 }
+                    _10KPlaytime = r.Float64
                     _10K = { Combined = r.Float32; Jacks = r.Float32; Chordstream = r.Float32; Stream = r.Float32 }
                 }
         }
 
     let get (user_id: int64) =
-        GET.Execute (user_id) core_db |> expect |> Array.tryExactlyOne
+        GET.Execute user_id core_db |> expect |> Array.tryExactlyOne
 
-    let get_or_default (user_id: int) =
+    let get_or_default (user_id: int64) =
         GET.Execute user_id core_db |> expect |> Array.tryExactlyOne |> Option.defaultValue DEFAULT
 
     let private SET: NonQuery<int64 * Stats> =
@@ -93,35 +118,41 @@ module Stats =
             SQL =
                 """
             INSERT OR REPLACE INTO stats (
-                UserId, LastSync, XP, Playtime,
-                _4KCombined, _4KJacks, _4KChordstream, _4KStream,
-                _7KCombined, _7KJacks, _7KChordstream, _7KStream,
-                _10KCombined, _10KJacks, _10KChordstream, _10KStream
+                UserId, LastSync, Playtime, PracticeTime, GameTime, NotesHit, XP,
+                _4KPlaytime, _4KCombined, _4KJacks, _4KChordstream, _4KStream,
+                _7KPlaytime, _7KCombined, _7KJacks, _7KChordstream, _7KStream,
+                _10KPlaytime, _10KCombined, _10KJacks, _10KChordstream, _10KStream
             )
             VALUES (
-                @UserId, @LastSync, @XP, @Playtime,
-                @_4KCombined, @_4KJacks, @_4KChordstream, @_4KStream,
-                @_7KCombined, @_7KJacks, @_7KChordstream, @_7KStream,
-                @_10KCombined, @_10KJacks, @_10KChordstream, @_10KStream,
+                @UserId, @LastSync, @Playtime, @PracticeTime, @GameTime, @NotesHit, @XP,
+                @_4KPlaytime, @_4KCombined, @_4KJacks, @_4KChordstream, @_4KStream,
+                @_7KPlaytime, @_7KCombined, @_7KJacks, @_7KChordstream, @_7KStream,
+                @_10KPlaytime, @_10KCombined, @_10KJacks, @_10KChordstream, @_10KStream
             );
             """
             Parameters =
                 [
                     "@UserId", SqliteType.Integer, 8
                     "@LastSync", SqliteType.Integer, 8
-                    "@XP", SqliteType.Integer, 8
                     "@Playtime", SqliteType.Real, 8
+                    "@PracticeTime", SqliteType.Real, 8
+                    "@GameTime", SqliteType.Real, 8
+                    "@NotesHit", SqliteType.Integer, 4
+                    "@XP", SqliteType.Integer, 8
 
+                    "@_4KPlaytime", SqliteType.Real, 8
                     "@_4KCombined", SqliteType.Real, 4
                     "@_4KJacks", SqliteType.Real, 4
                     "@_4KChordstream", SqliteType.Real, 4
                     "@_4KStream", SqliteType.Real, 4
 
+                    "@_7KPlaytime", SqliteType.Real, 8
                     "@_7KCombined", SqliteType.Real, 4
                     "@_7KJacks", SqliteType.Real, 4
                     "@_7KChordstream", SqliteType.Real, 4
                     "@_7KStream", SqliteType.Real, 4
 
+                    "@_10KPlaytime", SqliteType.Real, 8
                     "@_10KCombined", SqliteType.Real, 4
                     "@_10KJacks", SqliteType.Real, 4
                     "@_10KChordstream", SqliteType.Real, 4
@@ -131,19 +162,25 @@ module Stats =
                 (fun p (user_id, stats) ->
                     p.Int64 user_id
                     p.Int64 stats.LastSync
-                    p.Int64 stats.XP
                     p.Float64 stats.Playtime
+                    p.Float64 stats.PracticeTime
+                    p.Float64 stats.GameTime
+                    p.Float64 stats.NotesHit
+                    p.Int64 stats.XP
 
+                    p.Float64 stats._4KPlaytime
                     p.Float32 stats._4K.Combined
                     p.Float32 stats._4K.Jacks
                     p.Float32 stats._4K.Chordstream
                     p.Float32 stats._4K.Stream
 
+                    p.Float64 stats._7KPlaytime
                     p.Float32 stats._7K.Combined
                     p.Float32 stats._7K.Jacks
                     p.Float32 stats._7K.Chordstream
                     p.Float32 stats._7K.Stream
 
+                    p.Float64 stats._10KPlaytime
                     p.Float32 stats._10K.Combined
                     p.Float32 stats._10K.Jacks
                     p.Float32 stats._10K.Chordstream
@@ -154,21 +191,74 @@ module Stats =
     let set (user_id: int64) (stats: Stats) =
         SET.Execute (user_id, stats) core_db |> expect |> ignore
 
-    type TableLeaderboardModel = { UserId: int64; Rating: float }
+    type XPLeaderboardModel = { UserId: int64; XP: int64; Playtime: float }
 
-    let private LEADERBOARD: Query<string, TableLeaderboardModel> =
-        {
+    let private XP_LEADERBOARD: Query<unit, XPLeaderboardModel> =
+        { Query.without_parameters() with
             SQL =
                 """
-            SELECT UserId, Rating FROM table_ratings
-            WHERE TableId = @TableId
-            ORDER BY Rating DESC
+            SELECT UserId, XP, Playtime FROM stats
+            ORDER BY XP DESC
             LIMIT 50;
             """
-            Parameters = [ "@TableId", SqliteType.Text, -1 ]
-            FillParameters = fun p table_id -> p.String table_id
-            Read = (fun r -> { UserId = r.Int64; Rating = r.Float64 })
+            Read = (fun r -> { UserId = r.Int64; XP = r.Int64; Playtime = r.Float64 })
         }
 
-    let leaderboard (table_id: string) =
-        LEADERBOARD.Execute table_id core_db |> expect
+    let xp_leaderboard () =
+        XP_LEADERBOARD.Execute () core_db |> expect
+
+    type KeymodeLeaderboardModel =
+        {
+            UserId: int64
+            Playtime: float
+            Combined: float32
+            Jacks: float32
+            Chordstream: float32
+            Stream: float32
+        }
+
+    let private LEADERBOARD_4K: Query<unit, KeymodeLeaderboardModel> =
+        { Query.without_parameters() with
+            SQL =
+                """
+            SELECT UserId, _4KPlaytime, _4KCombined, _4KJacks, _4KChordstream, _4KStream FROM stats
+            ORDER BY _4KCombined DESC
+            LIMIT 50;
+            """
+            Read = (fun r ->
+                {
+                    UserId = r.Int64
+                    Playtime = r.Float64
+                    Combined = r.Float32
+                    Jacks = r.Float32
+                    Chordstream = r.Float32
+                    Stream = r.Float32
+                }
+            )
+        }
+
+    let leaderboard_4k () =
+        LEADERBOARD_4K.Execute () core_db |> expect
+
+    let private LEADERBOARD_7K: Query<unit, KeymodeLeaderboardModel> =
+        { Query.without_parameters() with
+            SQL =
+                """
+            SELECT UserId, _7KPlaytime, _7KCombined, _7KJacks, _7KChordstream, _7KStream FROM stats
+            ORDER BY _7KCombined DESC
+            LIMIT 50;
+            """
+            Read = (fun r ->
+                {
+                    UserId = r.Int64
+                    Playtime = r.Float64
+                    Combined = r.Float32
+                    Jacks = r.Float32
+                    Chordstream = r.Float32
+                    Stream = r.Float32
+                }
+            )
+        }
+
+    let leaderboard_7k () =
+        LEADERBOARD_7K.Execute () core_db |> expect

--- a/online/server/Domain/Database.fs
+++ b/online/server/Domain/Database.fs
@@ -68,6 +68,11 @@ module Migrations =
             )
             db
 
+        Database.migrate
+            "CreateStatsTable"
+            (fun db -> Stats.CREATE_TABLE.Execute () db |> expect |> ignore)
+            db
+
     open Interlude.Web.Server.Domain.Backbeat
 
     let run_backbeat (db: Database) : unit =

--- a/online/server/Domain/Database.fs
+++ b/online/server/Domain/Database.fs
@@ -73,6 +73,11 @@ module Migrations =
             (fun db -> Stats.CREATE_TABLE.Execute () db |> expect |> ignore)
             db
 
+        Database.migrate
+            "CreateMonthlyStatsTable"
+            (fun db -> MonthlyStats.CREATE_TABLE.Execute () db |> expect |> ignore)
+            db
+
     open Interlude.Web.Server.Domain.Backbeat
 
     let run_backbeat (db: Database) : unit =

--- a/online/server/Domain/Services/Stats.fs
+++ b/online/server/Domain/Services/Stats.fs
@@ -1,11 +1,7 @@
 ﻿namespace Interlude.Web.Server.Domain.Services
 
-open System
-open System.Collections.Generic
 open Percyqaz.Common
 open Prelude.Data.User.Stats
-open Interlude.Web.Shared
-open Interlude.Web.Server
 open Interlude.Web.Server.Domain.Core
 
 module Stats =

--- a/online/server/Domain/Services/Stats.fs
+++ b/online/server/Domain/Services/Stats.fs
@@ -47,18 +47,18 @@ module Stats =
                 _7KPlaytime = safe_stat_max all_time_stats._7KPlaytime (incoming.KeymodePlaytime.TryFind 7 |> Option.defaultValue 0.0)
                 _7K =
                     {
-                        Combined = max all_time_stats._7K.Combined incoming.KeymodeSkillsAllTime.[1].Combined
-                        Jacks = max all_time_stats._7K.Jacks incoming.KeymodeSkillsAllTime.[1].Jacks
-                        Chordstream = max all_time_stats._7K.Chordstream incoming.KeymodeSkillsAllTime.[1].Chordstream
-                        Stream = max all_time_stats._7K.Stream incoming.KeymodeSkillsAllTime.[1].Stream
+                        Combined = max all_time_stats._7K.Combined incoming.KeymodeSkillsAllTime.[4].Combined
+                        Jacks = max all_time_stats._7K.Jacks incoming.KeymodeSkillsAllTime.[4].Jacks
+                        Chordstream = max all_time_stats._7K.Chordstream incoming.KeymodeSkillsAllTime.[4].Chordstream
+                        Stream = max all_time_stats._7K.Stream incoming.KeymodeSkillsAllTime.[4].Stream
                     }
                 _10KPlaytime = safe_stat_max all_time_stats._10KPlaytime (incoming.KeymodePlaytime.TryFind 10 |> Option.defaultValue 0.0)
                 _10K =
                     {
-                        Combined = max all_time_stats._10K.Combined incoming.KeymodeSkillsAllTime.[1].Combined
-                        Jacks = max all_time_stats._10K.Jacks incoming.KeymodeSkillsAllTime.[1].Jacks
-                        Chordstream = max all_time_stats._10K.Chordstream incoming.KeymodeSkillsAllTime.[1].Chordstream
-                        Stream = max all_time_stats._10K.Stream incoming.KeymodeSkillsAllTime.[1].Stream
+                        Combined = max all_time_stats._10K.Combined incoming.KeymodeSkillsAllTime.[7].Combined
+                        Jacks = max all_time_stats._10K.Jacks incoming.KeymodeSkillsAllTime.[7].Jacks
+                        Chordstream = max all_time_stats._10K.Chordstream incoming.KeymodeSkillsAllTime.[7].Chordstream
+                        Stream = max all_time_stats._10K.Stream incoming.KeymodeSkillsAllTime.[7].Stream
                     }
             }
         Stats.save user_id new_all_time_stats
@@ -79,18 +79,18 @@ module Stats =
                 _7KPlaytime = safe_stat_max monthly_stats._7KPlaytime (incoming.KeymodePlaytimeThisMonth.TryFind 7 |> Option.defaultValue 0.0)
                 _7K =
                     {
-                        Combined = max monthly_stats._7K.Combined incoming.KeymodeSkillsRecent.[1].Combined
-                        Jacks = max monthly_stats._7K.Jacks incoming.KeymodeSkillsRecent.[1].Jacks
-                        Chordstream = max monthly_stats._7K.Chordstream incoming.KeymodeSkillsRecent.[1].Chordstream
-                        Stream = max monthly_stats._7K.Stream incoming.KeymodeSkillsRecent.[1].Stream
+                        Combined = max monthly_stats._7K.Combined incoming.KeymodeSkillsRecent.[4].Combined
+                        Jacks = max monthly_stats._7K.Jacks incoming.KeymodeSkillsRecent.[4].Jacks
+                        Chordstream = max monthly_stats._7K.Chordstream incoming.KeymodeSkillsRecent.[4].Chordstream
+                        Stream = max monthly_stats._7K.Stream incoming.KeymodeSkillsRecent.[4].Stream
                     }
                 _10KPlaytime = safe_stat_max monthly_stats._10KPlaytime (incoming.KeymodePlaytimeThisMonth.TryFind 10 |> Option.defaultValue 0.0)
                 _10K =
                     {
-                        Combined = max monthly_stats._10K.Combined incoming.KeymodeSkillsRecent.[1].Combined
-                        Jacks = max monthly_stats._10K.Jacks incoming.KeymodeSkillsRecent.[1].Jacks
-                        Chordstream = max monthly_stats._10K.Chordstream incoming.KeymodeSkillsRecent.[1].Chordstream
-                        Stream = max monthly_stats._10K.Stream incoming.KeymodeSkillsRecent.[1].Stream
+                        Combined = max monthly_stats._10K.Combined incoming.KeymodeSkillsRecent.[7].Combined
+                        Jacks = max monthly_stats._10K.Jacks incoming.KeymodeSkillsRecent.[7].Jacks
+                        Chordstream = max monthly_stats._10K.Chordstream incoming.KeymodeSkillsRecent.[7].Chordstream
+                        Stream = max monthly_stats._10K.Stream incoming.KeymodeSkillsRecent.[7].Stream
                     }
             }
         MonthlyStats.save month user_id new_monthly_stats

--- a/online/server/Domain/Services/Stats.fs
+++ b/online/server/Domain/Services/Stats.fs
@@ -1,0 +1,102 @@
+﻿namespace Interlude.Web.Server.Domain.Services
+
+open System
+open System.Collections.Generic
+open Percyqaz.Common
+open Prelude.Data.User.Stats
+open Interlude.Web.Shared
+open Interlude.Web.Server
+open Interlude.Web.Server.Domain.Core
+
+module Stats =
+
+    let sync (user_id: int64) (incoming: StatsSyncUpstream): Result<unit, string> =
+
+        let now = Timestamp.now()
+        let month = timestamp_to_leaderboard_month now
+        let all_time_stats = Stats.get_or_default user_id
+        let monthly_stats = MonthlyStats.get_or_default month user_id
+
+        if incoming.Month <> month then
+            Error "Stats month does not match server month"
+        else
+
+        if incoming.NetworkId <> user_id then
+            Error <| sprintf "Stats data is for user id #%i" incoming.NetworkId
+        else
+
+        let time_since_sync = float (now - all_time_stats.LastSync) + 1000.0
+        if incoming.GameTime - all_time_stats.GameTime > time_since_sync then
+            Error "Increase in gametime is greater than real life time elapsed since last sync"
+        elif incoming.Playtime - all_time_stats.Playtime > incoming.GameTime - all_time_stats.GameTime then
+            Error "Increase in playtime is greater than increase in gametime"
+        else
+
+        let new_all_time_stats: Stats =
+            {
+                LastSync = now
+                Playtime = safe_stat_max all_time_stats.Playtime incoming.Playtime
+                PracticeTime = safe_stat_max all_time_stats.PracticeTime incoming.PracticeTime
+                GameTime = safe_stat_max all_time_stats.GameTime incoming.GameTime
+                NotesHit = max all_time_stats.NotesHit incoming.NotesHit
+                XP = max all_time_stats.XP incoming.XP
+                _4KPlaytime = safe_stat_max all_time_stats._4KPlaytime (incoming.KeymodePlaytime.TryFind 4 |> Option.defaultValue 0.0)
+                _4K =
+                    {
+                        Combined = max all_time_stats._4K.Combined incoming.KeymodeSkillsAllTime.[1].Combined
+                        Jacks = max all_time_stats._4K.Jacks incoming.KeymodeSkillsAllTime.[1].Jacks
+                        Chordstream = max all_time_stats._4K.Chordstream incoming.KeymodeSkillsAllTime.[1].Chordstream
+                        Stream = max all_time_stats._4K.Stream incoming.KeymodeSkillsAllTime.[1].Stream
+                    }
+                _7KPlaytime = safe_stat_max all_time_stats._7KPlaytime (incoming.KeymodePlaytime.TryFind 7 |> Option.defaultValue 0.0)
+                _7K =
+                    {
+                        Combined = max all_time_stats._7K.Combined incoming.KeymodeSkillsAllTime.[1].Combined
+                        Jacks = max all_time_stats._7K.Jacks incoming.KeymodeSkillsAllTime.[1].Jacks
+                        Chordstream = max all_time_stats._7K.Chordstream incoming.KeymodeSkillsAllTime.[1].Chordstream
+                        Stream = max all_time_stats._7K.Stream incoming.KeymodeSkillsAllTime.[1].Stream
+                    }
+                _10KPlaytime = safe_stat_max all_time_stats._10KPlaytime (incoming.KeymodePlaytime.TryFind 10 |> Option.defaultValue 0.0)
+                _10K =
+                    {
+                        Combined = max all_time_stats._10K.Combined incoming.KeymodeSkillsAllTime.[1].Combined
+                        Jacks = max all_time_stats._10K.Jacks incoming.KeymodeSkillsAllTime.[1].Jacks
+                        Chordstream = max all_time_stats._10K.Chordstream incoming.KeymodeSkillsAllTime.[1].Chordstream
+                        Stream = max all_time_stats._10K.Stream incoming.KeymodeSkillsAllTime.[1].Stream
+                    }
+            }
+        Stats.save user_id new_all_time_stats
+
+        let new_monthly_stats: MonthlyStats =
+            {
+                LastSync = now
+                Playtime = safe_stat_max monthly_stats.Playtime incoming.PlaytimeThisMonth
+                XP = max monthly_stats.XP incoming.XPThisMonth
+                _4KPlaytime = safe_stat_max monthly_stats._4KPlaytime (incoming.KeymodePlaytimeThisMonth.TryFind 4 |> Option.defaultValue 0.0)
+                _4K =
+                    {
+                        Combined = max monthly_stats._4K.Combined incoming.KeymodeSkillsRecent.[1].Combined
+                        Jacks = max monthly_stats._4K.Jacks incoming.KeymodeSkillsRecent.[1].Jacks
+                        Chordstream = max monthly_stats._4K.Chordstream incoming.KeymodeSkillsRecent.[1].Chordstream
+                        Stream = max monthly_stats._4K.Stream incoming.KeymodeSkillsRecent.[1].Stream
+                    }
+                _7KPlaytime = safe_stat_max monthly_stats._7KPlaytime (incoming.KeymodePlaytimeThisMonth.TryFind 7 |> Option.defaultValue 0.0)
+                _7K =
+                    {
+                        Combined = max monthly_stats._7K.Combined incoming.KeymodeSkillsRecent.[1].Combined
+                        Jacks = max monthly_stats._7K.Jacks incoming.KeymodeSkillsRecent.[1].Jacks
+                        Chordstream = max monthly_stats._7K.Chordstream incoming.KeymodeSkillsRecent.[1].Chordstream
+                        Stream = max monthly_stats._7K.Stream incoming.KeymodeSkillsRecent.[1].Stream
+                    }
+                _10KPlaytime = safe_stat_max monthly_stats._10KPlaytime (incoming.KeymodePlaytimeThisMonth.TryFind 10 |> Option.defaultValue 0.0)
+                _10K =
+                    {
+                        Combined = max monthly_stats._10K.Combined incoming.KeymodeSkillsRecent.[1].Combined
+                        Jacks = max monthly_stats._10K.Jacks incoming.KeymodeSkillsRecent.[1].Jacks
+                        Chordstream = max monthly_stats._10K.Chordstream incoming.KeymodeSkillsRecent.[1].Chordstream
+                        Stream = max monthly_stats._10K.Stream incoming.KeymodeSkillsRecent.[1].Stream
+                    }
+            }
+        MonthlyStats.save month user_id new_monthly_stats
+
+        Ok()

--- a/online/server/Interlude.Web.Server.fsproj
+++ b/online/server/Interlude.Web.Server.fsproj
@@ -57,6 +57,8 @@
     <Compile Include="API\Friends\List.fs" />
     <Compile Include="API\Friends\Add.fs" />
     <Compile Include="API\Friends\Remove.fs" />
+    <Compile Include="API\Stats\Leaderboard\MonthlyXP.fs" />
+    <Compile Include="API\Stats\Leaderboard\XP.fs" />
     <Compile Include="API\Stats\Fetch.fs" />
     <Compile Include="API\Stats\Sync.fs" />
     <Compile Include="API\API.fs" />

--- a/online/server/Interlude.Web.Server.fsproj
+++ b/online/server/Interlude.Web.Server.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="Domain\Core\Friends.fs" />
     <Compile Include="Domain\Core\Replays.fs" />
     <Compile Include="Domain\Core\Scores.fs" />
+    <Compile Include="Domain\Core\Stats.fs" />
     <Compile Include="Domain\Core\Tables.fs" />
     <Compile Include="Domain\Backbeat\Sources.fs" />
     <Compile Include="Domain\Backbeat\Songs.fs" />

--- a/online/server/Interlude.Web.Server.fsproj
+++ b/online/server/Interlude.Web.Server.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Domain\Services\Tables.fs" />
     <Compile Include="Domain\Services\Scores.fs" />
     <Compile Include="Domain\Services\Users.fs" />
+    <Compile Include="Domain\Services\Stats.fs" />
     <Compile Include="Domain\Database.fs" />
     <Compile Include="Online\Sessions.fs" />
     <Compile Include="Online\Lobbies.fs" />
@@ -56,6 +57,8 @@
     <Compile Include="API\Friends\List.fs" />
     <Compile Include="API\Friends\Add.fs" />
     <Compile Include="API\Friends\Remove.fs" />
+    <Compile Include="API\Stats\Fetch.fs" />
+    <Compile Include="API\Stats\Sync.fs" />
     <Compile Include="API\API.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/online/shared/Requests.fs
+++ b/online/shared/Requests.fs
@@ -530,3 +530,139 @@ module Friends =
 
         let delete (user: string, callback: bool option -> unit) =
             Client.delete (snd ROUTE + "?user=" + escape user, callback)
+
+module Stats =
+
+    open Prelude.Data.User.Stats
+
+    /// requires login token as Authorization header
+    module Fetch =
+
+        let ROUTE = (GET, "/stats")
+
+        type Response = StatsSyncDownstream
+
+        let get (callback: Response option -> unit) =
+            Client.get<Response> (snd ROUTE, callback)
+
+    /// requires login token as Authorization header
+    module Sync =
+
+        let ROUTE = (POST, "/stats")
+
+        type Request = StatsSyncUpstream
+
+        let post (request: Request, callback: bool option -> unit) =
+            Client.post<Request> (snd ROUTE, request, callback)
+
+    module Leaderboard =
+
+        /// requires login token as Authorization header
+        module XP =
+
+            let ROUTE = (GET, "/leaderboard/xp")
+
+            [<Json.AutoCodec>]
+            type LeaderboardEntry =
+                {
+                    Username: string
+                    Color: int
+                    XP: int64
+                    Playtime: float
+                }
+
+            type Response = LeaderboardEntry array
+
+            let get (sort_by_playtime: bool, callback: Response option -> unit) =
+                Client.get<Response> (snd ROUTE + (if sort_by_playtime then "?sort=playtime" else ""), callback)
+
+        /// requires login token as Authorization header
+        module MonthlyXP =
+
+            let ROUTE = (GET, "/leaderboard/monthly/xp")
+
+            [<Json.AutoCodec>]
+            type LeaderboardEntry =
+                {
+                    Username: string
+                    Color: int
+                    XP: int64
+                    Playtime: float
+                }
+
+            type Response = LeaderboardEntry array
+
+            let get (sort_by_playtime: bool, callback: Response option -> unit) =
+                Client.get<Response> (snd ROUTE + (if sort_by_playtime then "?sort=playtime" else ""), callback)
+
+        /// requires login token as Authorization header
+        module Keymode =
+
+            let ROUTE = (GET, "/leaderboard/keymode")
+
+            [<Json.AutoCodec>]
+            type LeaderboardEntry =
+                {
+                    Username: string
+                    Color: int
+                    Playtime: float
+                    Combined: float32
+                    Jacks: float32
+                    Chordstream: float32
+                    Stream: float32
+                }
+
+            type Sort =
+                | Playtime
+                | Combined
+                | Jacks
+                | Chordstream
+                | Stream
+                override this.ToString() =
+                    match this with
+                    | Playtime -> "playtime"
+                    | Combined -> "combined"
+                    | Jacks -> "jacks"
+                    | Chordstream -> "chordstream"
+                    | Stream -> "stream"
+
+            type Response = LeaderboardEntry array
+
+            let get (keys: int, sort: Sort, callback: Response option -> unit) =
+                Client.get<Response> (snd ROUTE + "?sort=" + sort.ToString() + "&keys=" + keys.ToString(), callback)
+
+        /// requires login token as Authorization header
+        module MonthlyKeymode =
+
+            let ROUTE = (GET, "/leaderboard/monthly/keymode")
+
+            [<Json.AutoCodec>]
+            type LeaderboardEntry =
+                {
+                    Username: string
+                    Color: int
+                    Playtime: float
+                    Combined: float32
+                    Jacks: float32
+                    Chordstream: float32
+                    Stream: float32
+                }
+
+            type Sort =
+                | Playtime
+                | Combined
+                | Jacks
+                | Chordstream
+                | Stream
+                override this.ToString() =
+                    match this with
+                    | Playtime -> "playtime"
+                    | Combined -> "combined"
+                    | Jacks -> "jacks"
+                    | Chordstream -> "chordstream"
+                    | Stream -> "stream"
+
+            type Response = LeaderboardEntry array
+
+            let get (keys: int, sort: Sort, callback: Response option -> unit) =
+                Client.get<Response> (snd ROUTE + "?sort=" + sort.ToString() + "&keys=" + keys.ToString(), callback)

--- a/online/tests/domain/Core/Stats.fs
+++ b/online/tests/domain/Core/Stats.fs
@@ -1,0 +1,104 @@
+﻿namespace Interlude.Web.Tests.Domain.Core
+
+open NUnit.Framework
+open Percyqaz.Common
+open Interlude.Web.Server.Domain.Core
+
+module Stats =
+
+    [<Test>]
+    let Stats_RoundTrip () =
+        let user_id = User.create ("StatsRoundTrip", 0uL) |> User.save_new
+
+        let stats : Stats =
+            {
+                LastSync = Timestamp.now()
+                Playtime = 100.0
+                PracticeTime = 50.0
+                GameTime = 200.0
+                NotesHit = 48376
+                XP = 3273564L
+                _4KPlaytime = 60.0
+                _4K = { Combined = 12000.0f; Jacks = 5000.0f; Chordstream = 4000.0f; Stream = 3000.0f }
+                _7KPlaytime = 40.0
+                _7K = { Combined = 11000.0f; Jacks = 4500.0f; Chordstream = 3500.0f; Stream = 3000.0f }
+                _10KPlaytime = 0.0
+                _10K = { Combined = 10500.0f; Jacks = 3500.0f; Chordstream = 4000.0f; Stream = 3000.0f }
+            }
+
+        Stats.set user_id stats
+
+        let result = Stats.get user_id
+
+        Assert.AreEqual(Some stats, result)
+
+    [<Test>]
+    let Stats_Idempotence () =
+        let user_id = User.create ("StatsIdempotence", 0uL) |> User.save_new
+
+        let stats : Stats =
+            {
+                LastSync = Timestamp.now()
+                Playtime = 100.0
+                PracticeTime = 50.0
+                GameTime = 200.0
+                NotesHit = 48376
+                XP = 3273564L
+                _4KPlaytime = 60.0
+                _4K = { Combined = 12000.0f; Jacks = 5000.0f; Chordstream = 4000.0f; Stream = 3000.0f }
+                _7KPlaytime = 40.0
+                _7K = { Combined = 11000.0f; Jacks = 4500.0f; Chordstream = 3500.0f; Stream = 3000.0f }
+                _10KPlaytime = 0.0
+                _10K = { Combined = 10500.0f; Jacks = 3500.0f; Chordstream = 4000.0f; Stream = 3000.0f }
+            }
+
+        Stats.set user_id stats
+        Stats.set user_id stats
+        Stats.set user_id stats
+
+        let result = Stats.get user_id
+
+        Assert.AreEqual(Some stats, result)
+
+    [<Test>]
+    let Stats_DoesntExist () =
+        let user_id = User.create ("StatsDoesntExist", 0uL) |> User.save_new
+
+        let result = Stats.get user_id
+        let result_or_default = Stats.get_or_default user_id
+        Assert.AreEqual(None, result)
+        Assert.AreEqual(Stats.Default, result_or_default)
+
+    [<Test>]
+    let Stats_Leaderboards () =
+        let user_id = User.create ("StatsLeaderboard", 0uL) |> User.save_new
+
+        let stats : Stats =
+            {
+                LastSync = Timestamp.now()
+                Playtime = 1000.0
+                PracticeTime = 500.0
+                GameTime = 2000.0
+                NotesHit = 483767
+                XP = 32735648L
+                _4KPlaytime = 600.0
+                _4K = { Combined = 12000.0f; Jacks = 5000.0f; Chordstream = 4000.0f; Stream = 3000.0f }
+                _7KPlaytime = 400.0
+                _7K = { Combined = 11000.0f; Jacks = 4500.0f; Chordstream = 3500.0f; Stream = 3000.0f }
+                _10KPlaytime = 10.0
+                _10K = { Combined = 10500.0f; Jacks = 3500.0f; Chordstream = 4000.0f; Stream = 3000.0f }
+            }
+
+        Stats.set user_id stats
+
+        let result = Stats.xp_leaderboard ()
+        printfn "%A" result
+        Assert.True(result.Length >= 1)
+
+        let result = Stats.leaderboard_4k ()
+        printfn "%A" result
+        Assert.True(result.Length >= 1)
+
+        let result = Stats.leaderboard_7k ()
+        printfn "%A" result
+        Assert.True(result.Length >= 1)

--- a/online/tests/domain/Interlude.Web.Tests.Domain.fsproj
+++ b/online/tests/domain/Interlude.Web.Tests.Domain.fsproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Core\Stats.fs" />
-    <Compile Include="Core\Tables.fs" />
     <Compile Include="Core\Users.fs" />
     <Compile Include="Core\Friends.fs" />
     <Compile Include="Core\Replays.fs" />
     <Compile Include="Core\Scores.fs" />
+    <Compile Include="Core\Stats.fs" />
+    <Compile Include="Core\Tables.fs" />
     <Compile Include="Backbeat\Sources.fs" />
     <Compile Include="Backbeat\Songs.fs" />
     <Compile Include="Backbeat\Tables.fs" />

--- a/online/tests/domain/Interlude.Web.Tests.Domain.fsproj
+++ b/online/tests/domain/Interlude.Web.Tests.Domain.fsproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Core\Stats.fs" />
     <Compile Include="Core\Tables.fs" />
     <Compile Include="Core\Users.fs" />
     <Compile Include="Core\Friends.fs" />

--- a/online/tests/integration/Endpoints/Stats.fs
+++ b/online/tests/integration/Endpoints/Stats.fs
@@ -1,0 +1,81 @@
+﻿namespace Interlude.Web.Tests.Integration
+
+open NUnit.Framework
+open Interlude.Web.Shared.Requests
+open System.Threading
+
+module Stats =
+
+    [<Test>]
+    let Fetch () =
+
+        use done_signal = new AutoResetEvent(false)
+
+        Stats.Fetch.get (
+            Option.get
+            >> fun (res: Stats.Fetch.Response) ->
+                printfn "%A" res
+                done_signal.Set() |> ignore
+        )
+
+        Assert.IsTrue(done_signal.WaitOne(500))
+
+    [<Test>]
+    let Leaderboard_XP () =
+
+        use done_signal = new AutoResetEvent(false)
+
+        Stats.Leaderboard.XP.get (
+            false,
+            Option.get
+            >> fun (res: Stats.Leaderboard.XP.Response) ->
+                printfn "%A" res
+                done_signal.Set() |> ignore
+        )
+
+        Assert.IsTrue(done_signal.WaitOne(500))
+
+    [<Test>]
+    let Leaderboard_Playtime () =
+
+        use done_signal = new AutoResetEvent(false)
+
+        Stats.Leaderboard.XP.get (
+            true,
+            Option.get
+            >> fun (res: Stats.Leaderboard.XP.Response) ->
+                printfn "%A" res
+                done_signal.Set() |> ignore
+        )
+
+        Assert.IsTrue(done_signal.WaitOne(500))
+
+    [<Test>]
+    let Leaderboard_Monthly_XP () =
+
+        use done_signal = new AutoResetEvent(false)
+
+        Stats.Leaderboard.MonthlyXP.get (
+            false,
+            Option.get
+            >> fun (res: Stats.Leaderboard.MonthlyXP.Response) ->
+                printfn "%A" res
+                done_signal.Set() |> ignore
+        )
+
+        Assert.IsTrue(done_signal.WaitOne(500))
+
+    [<Test>]
+    let Leaderboard_Monthly_Playtime () =
+
+        use done_signal = new AutoResetEvent(false)
+
+        Stats.Leaderboard.MonthlyXP.get (
+            true,
+            Option.get
+            >> fun (res: Stats.Leaderboard.MonthlyXP.Response) ->
+                printfn "%A" res
+                done_signal.Set() |> ignore
+        )
+
+        Assert.IsTrue(done_signal.WaitOne(500))

--- a/online/tests/integration/Interlude.Web.Tests.Integration.fsproj
+++ b/online/tests/integration/Interlude.Web.Tests.Integration.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Endpoints\Tables.fs" />
     <Compile Include="Endpoints\Players.fs" />
     <Compile Include="Endpoints\Friends.fs" />
+    <Compile Include="Endpoints\Stats.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/prelude/src/Common.fs
+++ b/prelude/src/Common.fs
@@ -341,5 +341,3 @@ module Common =
             sprintf "%.0fm" ts.TotalMinutes
         else
             sprintf "%.0fs" ts.TotalSeconds
-
-    let timestamp_to_local_day (ts: int64) = Timestamp.to_datetime(ts).Subtract(TimeSpan.FromHours(4.0)).ToLocalTime().Date

--- a/prelude/src/Data/User/Sessions.fs
+++ b/prelude/src/Data/User/Sessions.fs
@@ -55,7 +55,7 @@ module DbSessions =
             SQL =
                 """
             ALTER TABLE sessions
-            ADD COLUMN KeymodePlaytime TEXT NOT NULL DEFAULT '{}'
+            ADD COLUMN KeymodePlaytime TEXT NOT NULL DEFAULT '[]'
             """
         }
 

--- a/prelude/src/Data/User/Stats/Helpers.fs
+++ b/prelude/src/Data/User/Stats/Helpers.fs
@@ -7,7 +7,7 @@ open Percyqaz.Common
 module StatsHelpers =
 
     let safe_stat_max (original: float) (incoming: float) =
-        if Double.IsFinite incoming && incoming >= 0.0 then
+        if Double.IsFinite incoming then
             max original incoming
         else
             Logging.Error "Incoming sync value was %f, ignoring" incoming

--- a/prelude/src/Data/User/Stats/Helpers.fs
+++ b/prelude/src/Data/User/Stats/Helpers.fs
@@ -1,0 +1,46 @@
+﻿namespace Prelude.Data.User.Stats
+
+[<AutoOpen>]
+module StatsHelpers =
+
+    let add_playtimes (total: Map<int, float>) (session: Map<int, float>) =
+        Map.fold
+            (fun (pt: Map<int, float>) keymode time ->
+                pt.Change(
+                    keymode,
+                    function
+                    | None -> Some time
+                    | Some t -> Some (time + t)
+                )
+            )
+            total
+            session
+
+    let format_long_time (time: float) =
+        let seconds = time / 1000.0
+        let minutes = seconds / 60.0
+        let hours = minutes / 60.0
+        let days = hours / 24.0
+
+        if days > 1 then
+            sprintf "%id %02ih %02im" (floor days |> int) (floor (hours % 24.0) |> int) (floor (minutes % 60.0) |> int)
+        elif hours > 1 then
+            sprintf "%ih %02im" (floor hours |> int) (floor (minutes % 60.0) |> int)
+        else
+            sprintf "%im %02is" (floor minutes |> int) (floor (seconds % 60.0) |> int)
+
+    let format_short_time (time: float) =
+        let seconds = time / 1000.0
+        let minutes = seconds / 60.0
+        let hours = minutes / 60.0
+
+        if hours >= 1 then
+            sprintf "%i:%02i:%02i" (floor hours |> int) (floor (minutes % 60.0) |> int) (floor (seconds % 60.0) |> int)
+        else
+            sprintf "%02i:%02i" (floor (minutes % 60.0) |> int) (floor (seconds % 60.0) |> int)
+
+    let current_level (xp: int64) =
+        (float xp / 999.0 |> sqrt |> floor |> int) + 1
+
+    let xp_for_level (level: int) =
+        int64 (level - 1) * int64 (level - 1) * 999L

--- a/prelude/src/Data/User/Stats/Helpers.fs
+++ b/prelude/src/Data/User/Stats/Helpers.fs
@@ -1,5 +1,8 @@
 ﻿namespace Prelude.Data.User.Stats
 
+open System
+open Percyqaz.Common
+
 [<AutoOpen>]
 module StatsHelpers =
 
@@ -44,3 +47,23 @@ module StatsHelpers =
 
     let xp_for_level (level: int) =
         int64 (level - 1) * int64 (level - 1) * 999L
+
+    /// The local "rhythm game calendar day" is a term I made up
+    /// It is the date this timestamp falls on relative to the user (i.e. respects the timezone of the machine)
+    /// BUT the next day starts at 4am instead of midnight
+    /// Example: A timestamp for 2am on the 2nd of January your time = "1st of January" as a rhythm game calendar day
+    /// Example: A timestamp for 11pm on the 1st of January your time = "1st of January" as well
+    /// Used to partition sessions into a calendar for stats viewing purposes
+    let timestamp_to_rg_calendar_day (ts: int64) = Timestamp.to_datetime(ts).Subtract(TimeSpan.FromHours(4.0)).ToLocalTime().Date
+
+    /// The global "rhythm game month" this timestamp falls into
+    /// Used for global monthly leaderboards which should be timezone-independent
+    /// The borders between months are exactly the standard borders in UTC
+    let timestamp_to_leaderboard_month (ts: int64) : int =
+        let utc_date = Timestamp.to_datetime(ts)
+        let start = 2025 * 12
+        utc_date.Month + utc_date.Year * 12 - start
+
+    let start_of_leaderboard_month (month: int) : int64 =
+        DateTime(2025 + month / 12, (month - 1) %% 12 + 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        |> Timestamp.from_datetime

--- a/prelude/src/Data/User/Stats/Helpers.fs
+++ b/prelude/src/Data/User/Stats/Helpers.fs
@@ -20,7 +20,7 @@ module StatsHelpers =
                     keymode,
                     function
                     | None -> Some time
-                    | Some t -> Some (op time t)
+                    | Some t -> Some (op t time)
                 )
             )
             total

--- a/prelude/src/Data/User/Stats/Migration.fs
+++ b/prelude/src/Data/User/Stats/Migration.fs
@@ -134,7 +134,7 @@ module private Migration =
         DbSessions.save_batch sessions database.Database
         PREVIOUS_SESSIONS <-
             sessions
-            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_local_day |> DateOnly.FromDateTime)
+            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_rg_calendar_day |> DateOnly.FromDateTime)
             |> Seq.map (fun (local_date, sessions) -> (local_date, List.ofSeq sessions))
             |> Map.ofSeq
         CURRENT_SESSION <- { CURRENT_SESSION with KeymodeSkills = current_skills }
@@ -206,7 +206,7 @@ module private Migration =
         MIGRATIONS <- MIGRATIONS.Add "BackfillKeymodePlaytime"
         PREVIOUS_SESSIONS <-
             sessions
-            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_local_day |> DateOnly.FromDateTime)
+            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_rg_calendar_day |> DateOnly.FromDateTime)
             |> Seq.map (fun (local_date, sessions) -> (local_date, List.ofSeq sessions))
             |> Map.ofSeq
         DbSessions.save_batch sessions database.Database

--- a/prelude/src/Data/User/Stats/Migration.fs
+++ b/prelude/src/Data/User/Stats/Migration.fs
@@ -1,0 +1,147 @@
+﻿namespace Prelude.Data.User.Stats
+
+open System
+open Percyqaz.Common
+open Prelude
+open Prelude.Gameplay
+open Prelude.Gameplay.Rulesets
+open Prelude.Data.User
+open Prelude.Data.Library
+
+module private Migration =
+
+    let initial_backfill_calculation (library: Library) (database: UserDatabase) : Session array * KeymodeSkillBreakdown array =
+
+        // calculate skillsets
+        let sc_j4 = SC.create 4
+        let sc_j4_id = Ruleset.hash sc_j4
+
+        for cc_key in library.Charts.Cache.Keys do
+            let cc = library.Charts.Cache.[cc_key]
+
+            let data = UserDatabase.get_chart_data cc.Hash database
+            match data.PersonalBests.TryFind(sc_j4_id) with
+            | Some pbs ->
+                for (acc, rate, _) in pbs.Accuracy do
+                    KeymodeSkillBreakdown.score cc.Patterns acc rate TOTAL_STATS.KeymodeSkills.[cc.Keys - 3] |> ignore
+            | None -> ()
+
+        // calculate session
+        let scores =
+            seq {
+                for chart_id in database.Cache.Keys do
+                    for score in database.Cache.[chart_id].Scores do
+                        yield chart_id, score
+            }
+            |> Seq.sortBy (snd >> _.Timestamp)
+            |> Array.ofSeq
+
+        let first_score_length =
+            if scores.Length = 0 then 0L else
+            match ChartDatabase.get_meta (fst scores.[0]) library.Charts with
+            | Some cc -> cc.Length / (snd scores.[0]).Rate |> int64
+            | None -> 2L * 60L * 1000L
+
+        let mutable session_start_time = if scores.Length = 0 then 0L else (snd scores.[0]).Timestamp - first_score_length
+        let mutable session_playing_time = 0.0f<ms / rate>
+        let mutable last_time = session_start_time
+        let mutable score_count = 0
+        let skills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default)
+
+        seq {
+            for chart_id, score in scores do
+
+                let score_length =
+                    match ChartDatabase.get_meta chart_id library.Charts with
+                    | Some cc ->
+
+                        let data = UserDatabase.get_chart_data cc.Hash database
+                        match data.PersonalBests.TryFind(sc_j4_id) with
+                        | Some pbs ->
+                            match PersonalBests.get_best_above score.Rate pbs.Accuracy with
+                            | Some (acc, rate, _) ->
+                                KeymodeSkillBreakdown.score cc.Patterns acc score.Rate skills.[cc.Keys - 3] |> ignore
+                            | None -> ()
+                        | None -> ()
+
+                        session_playing_time <- session_playing_time + cc.Length / score.Rate
+                        cc.Length / score.Rate |> int64
+                    | None -> 2L * 60L * 1000L
+
+                if score.Timestamp - last_time > SESSION_TIMEOUT then
+                    // start of new session
+                    yield {
+                        Start = session_start_time
+                        End = last_time
+
+                        PlayTime = session_playing_time |> float
+                        PracticeTime = 0.0
+                        GameTime = float (last_time - session_start_time)
+                        NotesHit = 0
+                        PlaysStarted = score_count
+                        PlaysCompleted = score_count
+                        PlaysQuit = 0
+                        PlaysRetried = 0
+
+                        XP = 0
+                        KeymodeSkills = skills |> Array.map _.Tiny
+                        KeymodePlaytime = Map.empty
+                    }
+                    session_start_time <- score.Timestamp - score_length
+                    session_playing_time <- 0.0f<ms / rate>
+                    score_count <- 1
+                    let d = KeymodeSkillBreakdown.decay_over_time last_time session_start_time
+                    for i = 0 to skills.Length - 1 do
+                        skills.[i] <- skills.[i].Scale d
+                else
+                    score_count <- score_count + 1
+                last_time <- score.Timestamp
+
+            if session_start_time > 0 then
+                yield {
+                    Start = session_start_time
+                    End = last_time
+
+                    PlayTime = session_playing_time |> float
+                    PracticeTime = 0.0
+                    GameTime = float (last_time - session_start_time)
+                    NotesHit = 0
+                    PlaysStarted = score_count
+                    PlaysCompleted = score_count
+                    PlaysQuit = 0
+                    PlaysRetried = 0
+
+                    XP = 0
+                    KeymodeSkills = skills |> Array.map _.Tiny
+                    KeymodePlaytime = Map.empty
+
+                }
+            let d = KeymodeSkillBreakdown.decay_over_time last_time (Timestamp.now())
+            for i = 0 to skills.Length - 1 do
+                skills.[i] <- skills.[i].Scale d
+        }
+        |> Seq.toArray,
+        skills
+
+    let migrate_legacy_stats (library: Library) (database: UserDatabase) =
+
+        Logging.Info("Backfilling session data from score history...")
+
+        TOTAL_STATS <- TotalStats.Default
+        CURRENT_SESSION <- CurrentSession.Default
+
+        let sessions, current_skills = initial_backfill_calculation library database
+        DbSessions.save_batch sessions database.Database
+        PREVIOUS_SESSIONS <-
+            sessions
+            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_local_day |> DateOnly.FromDateTime)
+            |> Seq.map (fun (local_date, sessions) -> (local_date, List.ofSeq sessions))
+            |> Map.ofSeq
+        CURRENT_SESSION <- { CURRENT_SESSION with KeymodeSkills = current_skills }
+
+        let legacy_stats = load_important_json_file "Stats" (System.IO.Path.Combine(get_game_folder "Data", "stats.json")) false
+        TOTAL_STATS <- { legacy_stats with XP = legacy_stats.NotesHit; KeymodeSkills = TOTAL_STATS.KeymodeSkills }
+
+    let migrate (library: Library) (database: UserDatabase) =
+        if PREVIOUS_SESSIONS = Map.empty && TOTAL_STATS.GameTime = 0.0 then
+            migrate_legacy_stats library database

--- a/prelude/src/Data/User/Stats/State.fs
+++ b/prelude/src/Data/User/Stats/State.fs
@@ -1,0 +1,166 @@
+﻿namespace Prelude.Data.User.Stats
+
+open System
+open Percyqaz.Common
+open Percyqaz.Data
+open Prelude.Gameplay
+
+type Session = Prelude.Data.User.Session
+
+// todo: make properties internal
+[<Json.AutoCodec(false)>]
+type CurrentSession =
+    {
+        Start: int64
+        mutable LastPlay: int64
+        mutable LastTime: int64
+
+        mutable PlayTime: float
+        mutable PracticeTime: float
+        mutable GameTime: float
+        mutable NotesHit: int
+
+        mutable PlaysStarted: int
+        mutable PlaysRetried: int
+        mutable PlaysCompleted: int
+        mutable PlaysQuit: int
+
+        mutable SessionScore: int64
+        mutable Streak: int
+        KeymodeSkills: KeymodeSkillBreakdown array
+        mutable KeymodePlaytime: Map<int, float>
+    }
+
+    member this.ToSession: Session =
+        assert(this.NotesHit > 0)
+        {
+            Start = this.Start
+            End = this.LastTime
+
+            PlayTime = this.PlayTime
+            PracticeTime = this.PracticeTime
+            GameTime = this.GameTime
+            NotesHit = this.NotesHit
+
+            PlaysStarted = this.PlaysStarted
+            PlaysRetried = this.PlaysRetried
+            PlaysCompleted = this.PlaysCompleted
+            PlaysQuit = this.PlaysQuit
+
+            XP = this.SessionScore
+            KeymodeSkills = this.KeymodeSkills |> Array.map _.Tiny
+            KeymodePlaytime = this.KeymodePlaytime
+        }
+
+    member this.AddPlaytime (keymode: int) (time: float) =
+        this.PlayTime <- this.PlayTime + time
+        this.KeymodePlaytime <- this.KeymodePlaytime.Change(keymode, fun v -> (Option.defaultValue 0.0 v) + time |> Some)
+
+    static member StartNew (now: int64) (end_of_last_session: int64) (previous_skills: KeymodeSkillBreakdown array) =
+        {
+            Start = now
+            LastPlay = now
+            LastTime = now
+
+            PlayTime = 0.0
+            PracticeTime = 0.0
+            GameTime = 0.0
+            NotesHit = 0
+
+            PlaysStarted = 0
+            PlaysRetried = 0
+            PlaysCompleted = 0
+            PlaysQuit = 0
+
+            SessionScore = 0L
+            Streak = 0
+            KeymodeSkills =
+                let d = KeymodeSkillBreakdown.decay_over_time end_of_last_session now
+                previous_skills |> Array.map (fun k -> k.Scale d)
+            KeymodePlaytime = Map.empty
+        }
+
+    static member Default =
+        let now = Timestamp.now()
+        {
+            Start = now
+            LastPlay = now
+            LastTime = now
+
+            PlayTime = 0.0
+            PracticeTime = 0.0
+            GameTime = 0.0
+            NotesHit = 0
+
+            PlaysStarted = 0
+            PlaysRetried = 0
+            PlaysCompleted = 0
+            PlaysQuit = 0
+
+            SessionScore = 0L
+            Streak = 0
+            KeymodeSkills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default)
+            KeymodePlaytime = Map.empty
+        }
+
+[<Json.AutoCodec(false)>]
+type TotalStats =
+    {
+        PlayTime: float
+        PracticeTime: float
+        GameTime: float
+        NotesHit: int
+
+        PlaysStarted: int
+        PlaysRetried: int
+        PlaysCompleted: int
+        PlaysQuit: int
+
+        XP: int64
+        KeymodeSkills: KeymodeSkillBreakdown array
+        KeymodePlaytime: Map<int, float>
+    }
+
+    static member Default =
+        {
+            PlayTime = 0.0
+            PracticeTime = 0.0
+            GameTime = 0.0
+            NotesHit = 0
+            PlaysStarted = 0
+            PlaysRetried = 0
+            PlaysCompleted = 0
+            PlaysQuit = 0
+
+            XP = 0L
+            KeymodeSkills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default)
+            KeymodePlaytime = Map.empty
+        }
+
+    member this.AddSession (session: CurrentSession) =
+        {
+            PlayTime = this.PlayTime + session.PlayTime
+            PracticeTime = this.PracticeTime + session.PracticeTime
+            GameTime = this.GameTime + session.GameTime
+            NotesHit = this.NotesHit + session.NotesHit
+
+            PlaysStarted = this.PlaysStarted + session.PlaysStarted
+            PlaysRetried = this.PlaysRetried + session.PlaysRetried
+            PlaysCompleted = this.PlaysCompleted + session.PlaysCompleted
+            PlaysQuit = this.PlaysQuit + session.PlaysQuit
+
+            XP = this.XP + session.SessionScore
+            KeymodeSkills = this.KeymodeSkills
+            KeymodePlaytime = add_playtimes this.KeymodePlaytime session.KeymodePlaytime
+        }
+
+[<AutoOpen>]
+module StatsState =
+
+    let SESSION_TIMEOUT = 2L * 60L * 60L * 1000L // 2 hours
+    let STREAK_TIMEOUT = 60L * 1000L // 1 minute
+
+    let mutable TOTAL_STATS : TotalStats = Unchecked.defaultof<_>
+    let mutable CURRENT_SESSION : CurrentSession = Unchecked.defaultof<_>
+    let mutable PREVIOUS_SESSIONS : Map<DateOnly, Session list> = Map.empty
+    let mutable LAST_ONLINE_SYNC = 0L

--- a/prelude/src/Data/User/Stats/State.fs
+++ b/prelude/src/Data/User/Stats/State.fs
@@ -161,8 +161,9 @@ type StatsSaveData =
         TotalStats: TotalStats
         CurrentSession: CurrentSession
         Migrations: Set<string>
+        BoundNetworkId: int64 option
     }
-    static member Default = { TotalStats = TotalStats.Default; CurrentSession = CurrentSession.Default; Migrations = Set.empty }
+    static member Default = { TotalStats = TotalStats.Default; CurrentSession = CurrentSession.Default; Migrations = Set.empty; BoundNetworkId = None }
 
 [<AutoOpen>]
 module StatsState =
@@ -174,12 +175,14 @@ module StatsState =
     let mutable TOTAL_STATS : TotalStats = Unchecked.defaultof<_>
     let mutable CURRENT_SESSION : CurrentSession = Unchecked.defaultof<_>
     let mutable PREVIOUS_SESSIONS : Map<DateOnly, Session list> = Map.empty
+    let mutable BOUND_NETWORK_ID = None
 
     let internal save_stats (database: UserDatabase) =
-        DbSingletons.save<StatsSaveData> "stats" { TotalStats = TOTAL_STATS; CurrentSession = CURRENT_SESSION; Migrations = MIGRATIONS } database.Database
+        DbSingletons.save<StatsSaveData> "stats" { TotalStats = TOTAL_STATS; CurrentSession = CURRENT_SESSION; Migrations = MIGRATIONS; BoundNetworkId = BOUND_NETWORK_ID } database.Database
 
     let internal load_stats (database: UserDatabase) =
         let stats : StatsSaveData = DbSingletons.get_or_default "stats" StatsSaveData.Default database.Database
         TOTAL_STATS <- stats.TotalStats
         CURRENT_SESSION <- stats.CurrentSession
         MIGRATIONS <- stats.Migrations
+        BOUND_NETWORK_ID <- stats.BoundNetworkId

--- a/prelude/src/Data/User/Stats/Stats.fs
+++ b/prelude/src/Data/User/Stats/Stats.fs
@@ -1,119 +1,21 @@
-﻿namespace Prelude.Data.User
+﻿namespace Prelude.Data.User.Stats
 
 open System
 open Percyqaz.Common
 open Percyqaz.Data
 open Prelude
 open Prelude.Gameplay
-open Prelude.Gameplay.Rulesets
-
-[<Json.AutoCodec(false)>]
-type CurrentSession =
-    {
-        mutable Start: int64
-        mutable LastPlay: int64
-        mutable LastTime: int64
-
-        mutable PlayTime: float
-        mutable PracticeTime: float
-        mutable GameTime: float
-        mutable NotesHit: int
-
-        mutable PlaysStarted: int
-        mutable PlaysRetried: int
-        mutable PlaysCompleted: int
-        mutable PlaysQuit: int
-
-        mutable SessionScore: int64
-        mutable Streak: int
-        KeymodeSkills: KeymodeSkillBreakdown array
-    }
-
-    static member StartNew (now: int64) (end_of_last_session: int64) (previous_skills: KeymodeSkillBreakdown array) =
-        {
-            Start = now
-            LastPlay = now
-            LastTime = now
-
-            PlayTime = 0.0
-            PracticeTime = 0.0
-            GameTime = 0.0
-            NotesHit = 0
-
-            PlaysStarted = 0
-            PlaysRetried = 0
-            PlaysCompleted = 0
-            PlaysQuit = 0
-
-            SessionScore = 0L
-            Streak = 0
-            KeymodeSkills =
-                let d = KeymodeSkillBreakdown.decay_over_time end_of_last_session now
-                previous_skills |> Array.map (fun k -> k.Scale d)
-        }
-
-    static member Default =
-        let now = Timestamp.now()
-        {
-            Start = now
-            LastPlay = now
-            LastTime = now
-
-            PlayTime = 0.0
-            PracticeTime = 0.0
-            GameTime = 0.0
-            NotesHit = 0
-
-            PlaysStarted = 0
-            PlaysRetried = 0
-            PlaysCompleted = 0
-            PlaysQuit = 0
-
-            SessionScore = 0L
-            Streak = 0
-            KeymodeSkills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default)
-        }
-
-[<Json.AutoCodec(false)>]
-type TotalStats =
-    {
-        PlayTime: float
-        PracticeTime: float
-        GameTime: float
-        NotesHit: int
-
-        PlaysStarted: int
-        PlaysRetried: int
-        PlaysCompleted: int
-        PlaysQuit: int
-
-        XP: int64
-        KeymodeSkills: KeymodeSkillBreakdown array
-    }
-    static member Default =
-        {
-            PlayTime = 0.0
-            PracticeTime = 0.0
-            GameTime = 0.0
-            NotesHit = 0
-            PlaysStarted = 0
-            PlaysRetried = 0
-            PlaysCompleted = 0
-            PlaysQuit = 0
-
-            XP = 0L
-            KeymodeSkills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default)
-        }
-
+open Prelude.Data.User
 open Prelude.Data.Library
 
-[<Json.AutoCodec>]
+[<Json.AutoCodec(false)>]
 type Stats =
     {
         TotalStats: TotalStats
         CurrentSession: CurrentSession
+        LastOnlineSync: int64
     }
-    static member Default = { TotalStats = TotalStats.Default; CurrentSession = CurrentSession.Default }
+    static member Default = { TotalStats = TotalStats.Default; CurrentSession = CurrentSession.Default; LastOnlineSync = 0L }
 
 type SessionXPGain =
     {
@@ -127,58 +29,23 @@ type SessionXPGain =
 
 module Stats =
 
-    let SESSION_TIMEOUT = 2L * 60L * 60L * 1000L // 2 hours
-    let STREAK_TIMEOUT = 60L * 1000L // 1 minute
-
-    let mutable TOTAL_STATS : TotalStats = Unchecked.defaultof<_>
-    let mutable CURRENT_SESSION : CurrentSession = Unchecked.defaultof<_>
-    let mutable PREVIOUS_SESSIONS : Map<DateOnly, Session list> = Map.empty
+    let save (database: UserDatabase) =
+        DbSingletons.save<Stats> "stats" { TotalStats = TOTAL_STATS; CurrentSession = CURRENT_SESSION; LastOnlineSync = LAST_ONLINE_SYNC } database.Database
 
     let private end_current_session (now: int64) (database: UserDatabase) =
-        TOTAL_STATS <-
-            {
-                PlayTime = TOTAL_STATS.PlayTime + CURRENT_SESSION.PlayTime
-                PracticeTime = TOTAL_STATS.PracticeTime + CURRENT_SESSION.PracticeTime
-                GameTime = TOTAL_STATS.GameTime + CURRENT_SESSION.GameTime
-                NotesHit = TOTAL_STATS.NotesHit + CURRENT_SESSION.NotesHit
-
-                PlaysStarted = TOTAL_STATS.PlaysStarted + CURRENT_SESSION.PlaysStarted
-                PlaysRetried = TOTAL_STATS.PlaysRetried + CURRENT_SESSION.PlaysRetried
-                PlaysCompleted = TOTAL_STATS.PlaysCompleted + CURRENT_SESSION.PlaysCompleted
-                PlaysQuit = TOTAL_STATS.PlaysQuit + CURRENT_SESSION.PlaysQuit
-
-                XP = TOTAL_STATS.XP + CURRENT_SESSION.SessionScore
-                KeymodeSkills = TOTAL_STATS.KeymodeSkills
-            }
+        TOTAL_STATS <- TOTAL_STATS.AddSession CURRENT_SESSION
         if CURRENT_SESSION.NotesHit > 0 then
-            let session : Session =
-                {
-                    Start = CURRENT_SESSION.Start
-                    End = CURRENT_SESSION.LastTime
+            let database_session : Session = CURRENT_SESSION.ToSession
 
-                    PlayTime = CURRENT_SESSION.PlayTime
-                    PracticeTime = CURRENT_SESSION.PracticeTime
-                    GameTime = CURRENT_SESSION.GameTime
-                    NotesHit = CURRENT_SESSION.NotesHit
-
-                    PlaysStarted = CURRENT_SESSION.PlaysStarted
-                    PlaysRetried = CURRENT_SESSION.PlaysRetried
-                    PlaysCompleted = CURRENT_SESSION.PlaysCompleted
-                    PlaysQuit = CURRENT_SESSION.PlaysQuit
-
-                    XP = CURRENT_SESSION.SessionScore
-                    KeymodeSkills = CURRENT_SESSION.KeymodeSkills |> Array.map _.Tiny
-                }
-            let date = timestamp_to_local_day session.Start |> DateOnly.FromDateTime
+            let date = timestamp_to_local_day database_session.Start |> DateOnly.FromDateTime
             match PREVIOUS_SESSIONS.TryFind date with
-            | Some sessions ->
-                PREVIOUS_SESSIONS <- PREVIOUS_SESSIONS.Add (date, session :: sessions)
-            | None ->
-                PREVIOUS_SESSIONS <- PREVIOUS_SESSIONS.Add (date, [session])
-            DbSessions.save session database.Database
+            | Some sessions -> PREVIOUS_SESSIONS <- PREVIOUS_SESSIONS.Add (date, database_session :: sessions)
+            | None -> PREVIOUS_SESSIONS <- PREVIOUS_SESSIONS.Add (date, [database_session])
+
+            DbSessions.save database_session database.Database
 
         CURRENT_SESSION <- CurrentSession.StartNew now CURRENT_SESSION.LastTime CURRENT_SESSION.KeymodeSkills
-        DbSingletons.save<Stats> "stats" { TotalStats = TOTAL_STATS; CurrentSession = CURRENT_SESSION } database.Database
+        save database
 
     let save_current_session (now: int64) (database: UserDatabase) =
         CURRENT_SESSION.LastTime <- now
@@ -188,7 +55,7 @@ module Stats =
             Logging.Error("System clock changes could break your session stats")
             end_current_session now database
         else
-            DbSingletons.save<Stats> "stats" { TotalStats = TOTAL_STATS; CurrentSession = CURRENT_SESSION } database.Database
+            save database
 
     let QUIT_PENALTY = -100L
     let quitter_penalty (database: UserDatabase) =
@@ -267,116 +134,6 @@ module Stats =
             SkillXP = skill_xp // todo: separate into session/all time
         }
 
-    let private calculate (library: Library) (database: UserDatabase) : Session array * KeymodeSkillBreakdown array =
-
-        // calculate skillsets
-        let sc_j4 = SC.create 4
-        let sc_j4_id = Ruleset.hash sc_j4
-
-        for cc_key in library.Charts.Cache.Keys do
-            let cc = library.Charts.Cache.[cc_key]
-
-            let data = UserDatabase.get_chart_data cc.Hash database
-            match data.PersonalBests.TryFind(sc_j4_id) with
-            | Some pbs ->
-                for (acc, rate, _) in pbs.Accuracy do
-                    KeymodeSkillBreakdown.score cc.Patterns acc rate TOTAL_STATS.KeymodeSkills.[cc.Keys - 3] |> ignore
-            | None -> ()
-
-        // calculate session
-        let scores =
-            seq {
-                for chart_id in database.Cache.Keys do
-                    for score in database.Cache.[chart_id].Scores do
-                        yield chart_id, score
-            }
-            |> Seq.sortBy (snd >> _.Timestamp)
-            |> Array.ofSeq
-
-        let first_score_length =
-            if scores.Length = 0 then 0L else
-            match ChartDatabase.get_meta (fst scores.[0]) library.Charts with
-            | Some cc -> cc.Length / (snd scores.[0]).Rate |> int64
-            | None -> 2L * 60L * 1000L
-
-        let mutable session_start_time = if scores.Length = 0 then 0L else (snd scores.[0]).Timestamp - first_score_length
-        let mutable session_playing_time = 0.0f<ms / rate>
-        let mutable last_time = session_start_time
-        let mutable score_count = 0
-        let skills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default)
-
-        seq {
-            for chart_id, score in scores do
-
-                let score_length =
-                    match ChartDatabase.get_meta chart_id library.Charts with
-                    | Some cc ->
-
-                        let data = UserDatabase.get_chart_data cc.Hash database
-                        match data.PersonalBests.TryFind(sc_j4_id) with
-                        | Some pbs ->
-                            match PersonalBests.get_best_above score.Rate pbs.Accuracy with
-                            | Some (acc, rate, _) ->
-                                KeymodeSkillBreakdown.score cc.Patterns acc score.Rate skills.[cc.Keys - 3] |> ignore
-                            | None -> ()
-                        | None -> ()
-
-                        session_playing_time <- session_playing_time + cc.Length / score.Rate
-                        cc.Length / score.Rate |> int64
-                    | None -> 2L * 60L * 1000L
-
-                if score.Timestamp - last_time > SESSION_TIMEOUT then
-                    // start of new session
-                    yield {
-                        Start = session_start_time
-                        End = last_time
-
-                        PlayTime = session_playing_time |> float
-                        PracticeTime = 0.0
-                        GameTime = float (last_time - session_start_time)
-                        NotesHit = 0
-                        PlaysStarted = score_count
-                        PlaysCompleted = score_count
-                        PlaysQuit = 0
-                        PlaysRetried = 0
-
-                        XP = 0
-                        KeymodeSkills = skills |> Array.map _.Tiny
-                    }
-                    session_start_time <- score.Timestamp - score_length
-                    session_playing_time <- 0.0f<ms / rate>
-                    score_count <- 1
-                    let d = KeymodeSkillBreakdown.decay_over_time last_time session_start_time
-                    for i = 0 to skills.Length - 1 do
-                        skills.[i] <- skills.[i].Scale d
-                else
-                    score_count <- score_count + 1
-                last_time <- score.Timestamp
-
-            if scores.Length > 0 then
-                yield {
-                    Start = session_start_time
-                    End = last_time
-
-                    PlayTime = session_playing_time |> float
-                    PracticeTime = 0.0
-                    GameTime = float (last_time - session_start_time)
-                    NotesHit = 0
-                    PlaysStarted = score_count
-                    PlaysCompleted = score_count
-                    PlaysQuit = 0
-                    PlaysRetried = 0
-                    KeymodeSkills = skills |> Array.map _.Tiny
-
-                    XP = 0
-                }
-            let d = KeymodeSkillBreakdown.decay_over_time last_time (Timestamp.now())
-            for i = 0 to skills.Length - 1 do
-                skills.[i] <- skills.[i].Scale d
-        }
-        |> Seq.toArray,
-        skills
-
     let init_startup (library: Library) (database: UserDatabase) =
 
         let sessions = DbSessions.get_all database.Database
@@ -389,24 +146,7 @@ module Stats =
         TOTAL_STATS <- stats.TotalStats
         CURRENT_SESSION <- stats.CurrentSession
 
-        if PREVIOUS_SESSIONS = Map.empty && TOTAL_STATS.GameTime = 0.0 then
-
-            Logging.Info("Backfilling session data from score history...")
-
-            TOTAL_STATS <- TotalStats.Default
-            CURRENT_SESSION <- CurrentSession.Default
-
-            let sessions, current_skills = calculate library database
-            DbSessions.save_batch sessions database.Database
-            PREVIOUS_SESSIONS <-
-                sessions
-                |> Seq.groupBy (fun session -> session.Start |> timestamp_to_local_day |> DateOnly.FromDateTime)
-                |> Seq.map (fun (local_date, sessions) -> (local_date, List.ofSeq sessions))
-                |> Map.ofSeq
-            CURRENT_SESSION <- { CURRENT_SESSION with KeymodeSkills = current_skills }
-
-            let legacy_stats = load_important_json_file "Stats" (System.IO.Path.Combine(get_game_folder "Data", "stats.json")) false
-            TOTAL_STATS <- { legacy_stats with XP = legacy_stats.NotesHit; KeymodeSkills = TOTAL_STATS.KeymodeSkills }
+        Migration.migrate library database
 
         let now = Timestamp.now()
         if CURRENT_SESSION.NotesHit = 0 then
@@ -416,32 +156,3 @@ module Stats =
         elif now < CURRENT_SESSION.LastTime then
             Logging.Error("System clock changes could break your session stats")
             end_current_session now database
-
-    let format_long_time (time: float) =
-        let seconds = time / 1000.0
-        let minutes = seconds / 60.0
-        let hours = minutes / 60.0
-        let days = hours / 24.0
-
-        if days > 1 then
-            sprintf "%id %02ih %02im" (floor days |> int) (floor (hours % 24.0) |> int) (floor (minutes % 60.0) |> int)
-        elif hours > 1 then
-            sprintf "%ih %02im" (floor hours |> int) (floor (minutes % 60.0) |> int)
-        else
-            sprintf "%im %02is" (floor minutes |> int) (floor (seconds % 60.0) |> int)
-
-    let format_short_time (time: float) =
-        let seconds = time / 1000.0
-        let minutes = seconds / 60.0
-        let hours = minutes / 60.0
-
-        if hours >= 1 then
-            sprintf "%i:%02i:%02i" (floor hours |> int) (floor (minutes % 60.0) |> int) (floor (seconds % 60.0) |> int)
-        else
-            sprintf "%02i:%02i" (floor (minutes % 60.0) |> int) (floor (seconds % 60.0) |> int)
-
-    let current_level (xp: int64) =
-        (float xp / 999.0 |> sqrt |> floor |> int) + 1
-
-    let xp_for_level (level: int) =
-        int64 (level - 1) * int64 (level - 1) * 999L

--- a/prelude/src/Data/User/Stats/Stats.fs
+++ b/prelude/src/Data/User/Stats/Stats.fs
@@ -26,7 +26,7 @@ module Stats =
         if CURRENT_SESSION.NotesHit > 0 then
             let database_session : Session = CURRENT_SESSION.ToSession
 
-            let date = timestamp_to_local_day database_session.Start |> DateOnly.FromDateTime
+            let date = timestamp_to_rg_calendar_day database_session.Start |> DateOnly.FromDateTime
             match PREVIOUS_SESSIONS.TryFind date with
             | Some sessions -> PREVIOUS_SESSIONS <- PREVIOUS_SESSIONS.Add (date, database_session :: sessions)
             | None -> PREVIOUS_SESSIONS <- PREVIOUS_SESSIONS.Add (date, [database_session])
@@ -128,7 +128,7 @@ module Stats =
         let sessions = DbSessions.get_all database.Database
         PREVIOUS_SESSIONS <-
             sessions
-            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_local_day |> DateOnly.FromDateTime)
+            |> Seq.groupBy (fun session -> session.Start |> timestamp_to_rg_calendar_day |> DateOnly.FromDateTime)
             |> Seq.map (fun (local_date, sessions) -> (local_date, List.ofSeq sessions))
             |> Map.ofSeq
         load_stats database

--- a/prelude/src/Data/User/Stats/Sync.fs
+++ b/prelude/src/Data/User/Stats/Sync.fs
@@ -7,21 +7,21 @@ open Prelude.Gameplay
 [<Json.AutoCodec>]
 type StatsSyncUpstream =
     {
-        PlayTime: float
+        Playtime: float
         PracticeTime: float
         GameTime: float
         NotesHit: int
 
         XP: int64
-        KeymodePlayTime: Map<int, float>
+        KeymodePlaytime: Map<int, float>
 
         KeymodeSkillsAllTime: KeymodeTinyBreakdown array
         KeymodeSkillsRecent: KeymodeTinyBreakdown array
 
         NetworkId: int64
         Month: int
-        KeymodePlayTimeThisMonth: Map<int, float>
-        PlayTimeThisMonth: float
+        KeymodePlaytimeThisMonth: Map<int, float>
+        PlaytimeThisMonth: float
         XPThisMonth: int64
     }
 
@@ -37,23 +37,23 @@ type StatsSyncUpstream =
             |> Array.ofSeq
 
         {
-            PlayTime = TOTAL_STATS.PlayTime + CURRENT_SESSION.PlayTime
+            Playtime = TOTAL_STATS.PlayTime + CURRENT_SESSION.PlayTime
             PracticeTime = TOTAL_STATS.PracticeTime + CURRENT_SESSION.PracticeTime
             GameTime = TOTAL_STATS.GameTime + CURRENT_SESSION.GameTime
             NotesHit = TOTAL_STATS.NotesHit + CURRENT_SESSION.NotesHit
 
             XP = TOTAL_STATS.XP + CURRENT_SESSION.SessionScore
-            KeymodePlayTime = add_playtimes TOTAL_STATS.KeymodePlaytime CURRENT_SESSION.KeymodePlaytime
+            KeymodePlaytime = add_playtimes TOTAL_STATS.KeymodePlaytime CURRENT_SESSION.KeymodePlaytime
 
             KeymodeSkillsAllTime = TOTAL_STATS.KeymodeSkills |> Array.map _.Tiny
             KeymodeSkillsRecent = CURRENT_SESSION.KeymodeSkills |> Array.map _.Tiny
 
             NetworkId = network_id
             Month = month
-            KeymodePlayTimeThisMonth =
+            KeymodePlaytimeThisMonth =
                 let month_playtimes = sessions |> Seq.map _.KeymodePlaytime |> Seq.fold add_playtimes Map.empty
                 add_playtimes month_playtimes CURRENT_SESSION.KeymodePlaytime
-            PlayTimeThisMonth =
+            PlaytimeThisMonth =
                 let month_playtime = sessions |> Array.sumBy _.PlayTime
                 month_playtime + CURRENT_SESSION.PlayTime
             XPThisMonth =

--- a/prelude/src/Data/User/Stats/Sync.fs
+++ b/prelude/src/Data/User/Stats/Sync.fs
@@ -84,12 +84,12 @@ type StatsSyncDownstream =
         BOUND_NETWORK_ID <- Some this.NetworkId
         TOTAL_STATS <-
             { TOTAL_STATS with
-                PlayTime = safe_stat_max TOTAL_STATS.PlayTime this.PlayTime
-                PracticeTime = safe_stat_max TOTAL_STATS.PracticeTime this.PracticeTime
-                GameTime = safe_stat_max TOTAL_STATS.GameTime this.GameTime
-                NotesHit = max TOTAL_STATS.NotesHit this.NotesHit
-                XP = max TOTAL_STATS.XP this.XP
-                KeymodePlaytime = combine_playtimes safe_stat_max TOTAL_STATS.KeymodePlaytime this.KeymodePlaytime
+                PlayTime = safe_stat_max TOTAL_STATS.PlayTime (this.PlayTime - CURRENT_SESSION.PlayTime)
+                PracticeTime = safe_stat_max TOTAL_STATS.PracticeTime (this.PracticeTime - CURRENT_SESSION.PracticeTime)
+                GameTime = safe_stat_max TOTAL_STATS.GameTime (this.GameTime - CURRENT_SESSION.GameTime)
+                NotesHit = max TOTAL_STATS.NotesHit (this.NotesHit - CURRENT_SESSION.NotesHit)
+                XP = max TOTAL_STATS.XP (this.XP - CURRENT_SESSION.SessionScore)
+                KeymodePlaytime = combine_playtimes safe_stat_max TOTAL_STATS.KeymodePlaytime (combine_playtimes (-) this.KeymodePlaytime CURRENT_SESSION.KeymodePlaytime)
             }
 
         Some this.NetworkId

--- a/prelude/src/Data/User/Stats/Sync.fs
+++ b/prelude/src/Data/User/Stats/Sync.fs
@@ -79,6 +79,7 @@ type StatsSyncDownstream =
         match BOUND_NETWORK_ID with
         | Some id when id <> this.NetworkId -> None
         | _ ->
+        // in theory if never synced, could ADD online stats to current
 
         BOUND_NETWORK_ID <- Some this.NetworkId
         TOTAL_STATS <-

--- a/prelude/src/Data/User/UserDatabase.fs
+++ b/prelude/src/Data/User/UserDatabase.fs
@@ -208,6 +208,11 @@ module UserDatabase =
             )
             db
 
+        Database.migrate
+            "AddKeymodePlaytimeStats"
+            (fun db -> DbSessions.ADD_KEYMODE_PLAYTIME.Execute () db |> expect |> ignore)
+            db
+
         db
 
     let private legacy_migrate (db: UserDatabase) : UserDatabase =

--- a/prelude/src/Gameplay/Scoring/Events.fs
+++ b/prelude/src/Gameplay/Scoring/Events.fs
@@ -8,11 +8,11 @@ open Prelude.Gameplay.Rulesets
 type GameplayActionInternal =
     | HIT of delta: GameplayTime * missed: bool
     | HOLD of delta: GameplayTime * missed: bool
-    | RELEASE of 
-        release_delta: GameplayTime * 
-        missed: bool * 
-        overhold: bool * 
-        dropped: bool * 
+    | RELEASE of
+        release_delta: GameplayTime *
+        missed: bool *
+        overhold: bool *
+        dropped: bool *
         head_delta: GameplayTime *
         missed_head: bool
     | DROP_HOLD
@@ -47,7 +47,6 @@ type private HoldStateInternal =
         | H_MISSED_HEAD_DROPPED
         | H_MISSED_HEAD_REGRABBED -> true
         | _ -> false
-        
 
 [<Struct>]
 [<RequireQualifiedAccess>]
@@ -104,7 +103,7 @@ type GameplayEventProcessor(ruleset: Ruleset, keys: int, replay: IReplayProvider
                 assert(status.[k] <> HitFlags.RELEASE_ACCEPTED)
 
                 if status.[k] = HitFlags.RELEASE_REQUIRED then
-                    
+
                     status.[k] <- HitFlags.RELEASE_ACCEPTED
                     hold_states.[k] <- H_NOTHING, head_index
 
@@ -160,7 +159,7 @@ type GameplayEventProcessor(ruleset: Ruleset, keys: int, replay: IReplayProvider
 
     member this.Finished = expired_notes_index = hit_data.Length
 
-    /// Result of calling this: 
+    /// Result of calling this:
     ///  notes.[expired_notes_index - 1].Time < now - LATE WINDOW
     ///  notes.[expired_notes_index].Time >= now - LATE WINDOW
     ///  All notes on rows before `expired_notes_index` now have an action assigned - if there wasn't one before, it is now marked as missed
@@ -319,7 +318,7 @@ type GameplayEventProcessor(ruleset: Ruleset, keys: int, replay: IReplayProvider
                 let overhold =
                     if delta > late_release_window_scaled then
                         true
-                    else 
+                    else
                         deltas.[k] <- delta / rate
                         false
 
@@ -372,7 +371,7 @@ type GameplayEventProcessor(ruleset: Ruleset, keys: int, replay: IReplayProvider
     /// Result of calling this with a particular `chart_time`:
     /// - All replay inputs up to `chart_time` have been processed into hits by finding which notes/releases they correspond to with what timing
     /// - Notes where the time has passed to hit them, with no input mapping to them, have been processed as misses
-    
+
     /// Expected to be called with monotonically increasing values of `chart_time` during gameplay for live scoring
     /// For processing an entire score instantly pass in Time.infinity or any time higher than the duration of the chart + late window
 

--- a/prelude/src/Gameplay/Skillsets/Skillsets.fs
+++ b/prelude/src/Gameplay/Skillsets/Skillsets.fs
@@ -32,6 +32,14 @@ type KeymodeTinyBreakdown =
         Combined: float32
     }
 
+    static member Default =
+        {
+            Jacks = 0.0f
+            Chordstream = 0.0f
+            Stream = 0.0f
+            Combined = 0.0f
+        }
+
 [<Json.AutoCodec>]
 type KeymodeSkillBreakdown =
     {

--- a/prelude/src/Prelude.fsproj
+++ b/prelude/src/Prelude.fsproj
@@ -107,6 +107,7 @@
     <Compile Include="Data\User\ScoreInfo.fs" />
     <Compile Include="Data\User\Stats\Helpers.fs" />
     <Compile Include="Data\User\Stats\State.fs" />
+    <Compile Include="Data\User\Stats\Sync.fs" />
     <Compile Include="Data\User\Stats\Migration.fs" />
     <Compile Include="Data\User\Stats\Stats.fs" />
     <Compile Include="Data\Maintenance\PersonalBests.fs" />

--- a/prelude/src/Prelude.fsproj
+++ b/prelude/src/Prelude.fsproj
@@ -105,6 +105,9 @@
     <Compile Include="Data\Library\Views\Views.fs" />
     <Compile Include="Data\Library\Endless.fs" />
     <Compile Include="Data\User\ScoreInfo.fs" />
+    <Compile Include="Data\User\Stats\Helpers.fs" />
+    <Compile Include="Data\User\Stats\State.fs" />
+    <Compile Include="Data\User\Stats\Migration.fs" />
     <Compile Include="Data\User\Stats\Stats.fs" />
     <Compile Include="Data\Maintenance\PersonalBests.fs" />
     <Compile Include="Data\OsuClientInterop\Database.fs" />

--- a/prelude/tests/Database/DbSessions.fs
+++ b/prelude/tests/Database/DbSessions.fs
@@ -34,6 +34,7 @@ module DbSessions =
 
                 XP = 567L
                 KeymodeSkills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default.Tiny)
+                KeymodePlaytime = Map.ofSeq [4, 3600.0; 7, 1800.0]
             }
 
         DbSessions.save session db
@@ -41,7 +42,7 @@ module DbSessions =
         Assert.IsNotEmpty(result)
         Assert.AreEqual(session, result.[0])
         Assert.AreEqual(1, result.Length)
-    
+
     [<Test>]
     let Idempotence () =
         let db, conn = in_memory ()
@@ -63,6 +64,7 @@ module DbSessions =
 
                 XP = 567L
                 KeymodeSkills = Array.init 8 (fun _ -> KeymodeSkillBreakdown.Default.Tiny)
+                KeymodePlaytime = Map.ofSeq [4, 3600.0; 7, 1800.0]
             }
 
         DbSessions.save session db

--- a/prelude/tests/Prelude.Tests.fsproj
+++ b/prelude/tests/Prelude.Tests.fsproj
@@ -41,6 +41,7 @@
     <Compile Include="Rulesets\Graph.fs" />
     <Compile Include="Rulesets\OsuParity.fs" />
     <Compile Include="Rulesets\QuaverParity.fs" />
+    <Compile Include="Stats\Stats.fs" />
     <Compile Include="Database\Helpers.fs" />
     <Compile Include="Database\UserDatabase.fs" />
     <Compile Include="Database\DbScores.fs" />

--- a/prelude/tests/Stats/Stats.fs
+++ b/prelude/tests/Stats/Stats.fs
@@ -1,6 +1,8 @@
 ﻿namespace Prelude.Tests.Stats
 
+open System
 open NUnit.Framework
+open Percyqaz.Common
 open Prelude.Data.User.Stats
 
 module Stats =
@@ -26,3 +28,25 @@ module Stats =
 
         let combined2 = add_playtimes incoming original
         Assert.AreEqual(original, combined2)
+
+    [<Test>]
+    let LeaderboardMonths_FromTimestamp () =
+        let start_of_2025 = DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) |> Timestamp.from_datetime
+
+        Assert.AreEqual(0, timestamp_to_leaderboard_month (start_of_2025 - 1L))
+        Assert.AreEqual(1, timestamp_to_leaderboard_month start_of_2025)
+        Assert.AreEqual(1, timestamp_to_leaderboard_month (start_of_2025 + 1L))
+
+        let may_2025 = DateTime(2025, 5, 24, 12, 34, 56, DateTimeKind.Utc) |> Timestamp.from_datetime
+
+        Assert.AreEqual(5, timestamp_to_leaderboard_month (may_2025 - 1L))
+        Assert.AreEqual(5, timestamp_to_leaderboard_month may_2025)
+        Assert.AreEqual(5, timestamp_to_leaderboard_month (may_2025 + 1L))
+
+    [<Test>]
+    let LeaderboardMonths_ToTimestamp () =
+        let start_of_2025 = DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) |> Timestamp.from_datetime
+        Assert.AreEqual(start_of_2025, start_of_leaderboard_month 1)
+
+        let may_2025 = DateTime(2025, 5, 24, 12, 34, 56, DateTimeKind.Utc) |> Timestamp.from_datetime
+        Assert.AreEqual(5, timestamp_to_leaderboard_month (may_2025 - 1L) |> start_of_leaderboard_month |> timestamp_to_leaderboard_month)

--- a/prelude/tests/Stats/Stats.fs
+++ b/prelude/tests/Stats/Stats.fs
@@ -1,0 +1,28 @@
+﻿namespace Prelude.Tests.Stats
+
+open NUnit.Framework
+open Prelude.Data.User.Stats
+
+module Stats =
+
+    [<Test>]
+    let MergeKeymodePlaytimes_CaseA () =
+        let original = Map.ofSeq [ 4, 3600.0; 7, 1800.0 ]
+        let incoming = Map.ofSeq [ 8, 900.0; 4, 400.0 ]
+
+        let combined = add_playtimes original incoming
+        Assert.AreEqual(3, combined.Count)
+        Assert.AreEqual(Some 4000.0, combined.TryFind 4)
+        Assert.AreEqual(Some 1800.0, combined.TryFind 7)
+        Assert.AreEqual(Some 900.0, combined.TryFind 8)
+
+    [<Test>]
+    let MergeKeymodePlaytimes_CaseB () =
+        let original = Map.ofSeq [ 4, 3600.0; 7, 1800.0 ]
+        let incoming = Map.empty
+
+        let combined = add_playtimes original incoming
+        Assert.AreEqual(original, combined)
+
+        let combined2 = add_playtimes incoming original
+        Assert.AreEqual(original, combined2)


### PR DESCRIPTION
This PR adds:
- Keymode-specific playtime stats (which are backfilled when you update your client)
- Syncing stats between the client and server
- Endpoints for fetching leaderboards (but no way to see them ingame yet)

Bonus: Contains a bug fix for transitioning between fullscreen letterboxed and fullscreen
Bonus: Contains a wiki fix for rulesets