### PR TITLE
Investigation: Lower OpenGL requirement to 3.0+ instead of 3.3+

### DIFF
--- a/engine/src/Resources/shader.frag
+++ b/engine/src/Resources/shader.frag
@@ -1,4 +1,4 @@
-﻿#version 330 core
+﻿#version 130
 in vec2 fUv;
 in vec4 fColor;
 in float fTexLayer;

--- a/engine/src/Resources/shader.vert
+++ b/engine/src/Resources/shader.vert
@@ -1,8 +1,8 @@
-﻿#version 330 core
-layout (location = 0) in vec2 vPos;
-layout (location = 1) in vec2 vUv;
-layout (location = 2) in vec4 vColor;
-layout (location = 3) in float vTexLayer;
+﻿#version 130
+in vec2 vPos;
+in vec2 vUv;
+in vec4 vColor;
+in float vTexLayer;
 
 uniform mat4 uProjection;
 

--- a/engine/src/Windowing/WindowThread.fs
+++ b/engine/src/Windowing/WindowThread.fs
@@ -322,10 +322,14 @@ module WindowThread =
         GLFW.WindowHint(WindowHintBool.Focused, false)
         GLFW.WindowHint(WindowHintBool.AutoIconify, true)
         GLFW.WindowHint(WindowHintBool.Decorated, false)
-        GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core)
-        GLFW.WindowHint(WindowHintBool.OpenGLForwardCompat, true)
-        GLFW.WindowHint(WindowHintInt.ContextVersionMajor, 3)
-        GLFW.WindowHint(WindowHintInt.ContextVersionMinor, 3)
+        if OperatingSystem.IsMacOS() then
+            GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core)
+            GLFW.WindowHint(WindowHintBool.OpenGLForwardCompat, true)
+            GLFW.WindowHint(WindowHintInt.ContextVersionMajor, 3)
+            GLFW.WindowHint(WindowHintInt.ContextVersionMinor, 3)
+        else
+            GLFW.WindowHint(WindowHintInt.ContextVersionMajor, 3)
+            GLFW.WindowHint(WindowHintInt.ContextVersionMinor, 0)
         GLFW.WindowHint(WindowHintInt.Samples, config.MSAASamples)
         GLFW.WindowHint(WindowHintInt.StencilBits, 8)
         GLFW.WindowHint(WindowHintInt.DepthBits, 8)

--- a/engine/src/Windowing/WindowThread.fs
+++ b/engine/src/Windowing/WindowThread.fs
@@ -346,9 +346,8 @@ module WindowThread =
             | ErrorCode.VersionUnavailable ->
                 Logging.Critical ""
                 Logging.Critical "=== Helpful message from Percyqaz ==="
-                Logging.Critical "This error means your PC doesn't support OpenGL 3.3 or higher, and so can't run '%s' :(" title
-                Logging.Critical "If you think your PC DOES support OpenGL 3.3+, make sure you have up-to-date drivers; Complain in the Discord if the problem persists"
-                Logging.Critical "If your PC is from about 2011/12 and supports OpenGL 3.0-3.2, complain in the Discord anyway and I could spend more time seeing if the engine can be more backwards compatible"
+                Logging.Critical "This error means your PC doesn't support OpenGL 3.0 or higher, and so can't run '%s' :(" title
+                Logging.Critical "If you think your PC DOES support OpenGL 3.0+, make sure you have up-to-date drivers; Complain in the Discord if the problem persists"
                 Logging.Critical ""
             | ErrorCode.ApiUnavailable ->
                 Logging.Critical ""

--- a/site/files/download.html
+++ b/site/files/download.html
@@ -38,11 +38,10 @@
 
           <div class="frame text-2xl text-center p-4 flex flex-col">
              <h3 class="text-3xl">Minimum requirements</h3>
-             <p>64-bit Operating System*</p>
-             <p>OpenGL 3.3+/Intel HD Graphics 3000*</p>
+             <p>64-bit Operating System</p>
+             <p>OpenGL 3.0+/Intel HD Graphics 3000</p>
              <p>500MB free disk space</p>
              <p>2GB RAM</p>
-			 <p class="mt-4">*May get lower in future, where possible</p>
           </div>
 
           <div class="frame text-2xl text-center p-4">


### PR DESCRIPTION
This PR removes some OpenGL 3.3+ features from the shaders without changing behaviour*, and changes the minimum context version to 3.0

*at least, it does the same thing on my hardware? Assumption may need to be tested

Game launches and runs fine, with no change in performance seen, as my GPU still gives the game a 4.6.0 context either way

I tried sending these builds to some users whose hardware only supports GL 3.0-3.2 but not 3.3+ and the game launched but all they could see was a black screen :(

So next steps in investigating this are:
- Get hold of hardware that only supports GL 3.0-3.2 to test directly on
- OR figure out how to force my GPU drivers to give an exact 3.0 context, since something they are doing now is hiding an error the older hardware is encountering
- OR debug by remote-control by putting a ton of GL error logging into the render engine, then send a guinea pig a build to collect info