### PR TITLE
Various audio engine improvements

### DIFF
--- a/engine/src/Audio/Song.fs
+++ b/engine/src/Audio/Song.fs
@@ -10,9 +10,9 @@ type Song =
     {
         ID: int
         Frequency: int // in hz
-        Duration: float32<ms>
-        PreviewPoint: float32<ms>
-        LastNote: float32<ms>
+        Duration: Time
+        PreviewPoint: Time
+        LastNote: Time
         mutable LowPassFilterEffect: int
     }
     static member Default =
@@ -25,7 +25,7 @@ type Song =
             LowPassFilterEffect = 0
         }
 
-    static member FromFile(preview_point: float32<ms>, last_note: float32<ms>, file: string) =
+    static member FromFile(preview_point: Time, last_note: Time, file: string) =
         let ID = Bass.CreateStream(file, 0L, 0L, BassFlags.Prescan ||| BassFlags.Decode)
 
         if ID = 0 then

--- a/engine/src/Audio/Waveform.fs
+++ b/engine/src/Audio/Waveform.fs
@@ -18,10 +18,9 @@ module Waveform =
 
     type Waveform =
         {
-            MsPerPoint: float32<ms>
+            MsPerPoint: Time
             Points: Point array
         }
-
 
     let private samples_per_second = 1000
     let private points_per_iteration = 1000

--- a/engine/src/UI/Components/Performance.fs
+++ b/engine/src/UI/Components/Performance.fs
@@ -62,6 +62,8 @@ type PerformanceMonitor() =
 
     override this.Draw() =
         if enable then
+            Render.quad (this.Bounds.SliceL(600.0f).AsQuad) (Quad.gradient_left_to_right Colors.black.O3 Colors.black.O0)
+
             Text.draw_b (
                 Style.font,
                 sprintf "%.3f FPS" fps,
@@ -91,10 +93,19 @@ type PerformanceMonitor() =
 
             Text.draw_b (
                 Style.font,
+                sprintf "%.1fms audio compensation" Song.seek_inaccuracy_compensation,
+                30.0f,
+                this.Bounds.Left + 20.0f,
+                this.Bounds.Top + 140.0f,
+                (Color.White, Color.Black)
+            )
+
+            Text.draw_b (
+                Style.font,
                 sprintf "%O to show fps" fps_bind,
                 30.0f,
                 this.Bounds.Left + 20.0f,
-                this.Bounds.Top + 150.0f,
+                this.Bounds.Top + 190.0f,
                 Colors.text_subheading
             )
 
@@ -103,7 +114,7 @@ type PerformanceMonitor() =
                 sprintf "%O to show fps + graph" graph_bind,
                 30.0f,
                 this.Bounds.Left + 20.0f,
-                this.Bounds.Top + 190.0f,
+                this.Bounds.Top + 230.0f,
                 Colors.text_subheading
             )
 

--- a/engine/src/Windowing/GameThread.fs
+++ b/engine/src/Windowing/GameThread.fs
@@ -139,8 +139,8 @@ module GameThread =
 
     let private dispatch_frame (ui_root: UIEntryPoint) =
 
-        visual_latency_lo <- frame_is_ready - real_next_frame
-        visual_latency_hi <- start_of_frame - real_next_frame
+        visual_latency_lo <- real_next_frame - frame_is_ready
+        visual_latency_hi <- real_next_frame - start_of_frame
 
         match strategy with
 

--- a/interlude/src/Features/LevelSelect/Shared.fs
+++ b/interlude/src/Features/LevelSelect/Shared.fs
@@ -216,7 +216,7 @@ module LevelSelect =
                     Screen.change_new
                         (fun () -> ReplayScreen.replay_screen (info.Chart, ReplayMode.Auto info.WithColors) :> Screen.T)
                         Screen.Type.Replay
-                        Transitions.Default
+                        Transitions.EnterGameplayFadeAudio
                     |> ignore
                 else
                     play info
@@ -243,7 +243,7 @@ module LevelSelect =
                     :> Screen.T
                 )
                 Screen.Type.Replay
-                Transitions.Default
+                Transitions.EnterGameplayFadeAudio
         then
             SelectedChart.rate.Value <- score_info.Rate
 


### PR DESCRIPTION
The improvements are as follows:
- Added a 200ms crossfade when switching songs (requested by Adri)
  I like how it sounds, currently no plans to make this toggleable
- Charts with a preview time set out-of-bounds for the audio file now default to a preview time in the middle of the audio instead
- When viewing a replay, the song audio now correctly fades like it does for entering gameplay
- Experimental offset compensation from last week is now less experimental and should fix several issues:
  - Audio offset being slightly random from retry to retry by +-2ms
  - Audio offset drifting depending on rate (it should now not drift at all)
  - Any inconsistency/drift depending on audio settings (pitch rates, muffle menu effect, etc)
- Improved performance overlay to reflect this new stuff + Fixed playfield latency being negative + Gave it a background to make it easier to read