### PR TITLE
Fix NullReferenceException on Etterna skin import

### DIFF
--- a/interlude/src/Features/Import/Etterna/Skins.fs
+++ b/interlude/src/Features/Import/Etterna/Skins.fs
@@ -26,7 +26,7 @@ module Skins =
                 .WithConditional(
                     existing_folder.IsSome,
 
-                    Text([existing_folder.Value] %> "etterna_skin_import.delete_prompt")
+                    Text([existing_folder |> Option.defaultValue ""] %> "etterna_skin_import.delete_prompt")
                         .Align(Alignment.LEFT)
                         .TextPos(5),
                     PageSetting(%"etterna_skin_import.delete_existing", Checkbox delete_existing)


### PR DESCRIPTION
Game throws a `NullReferenceException` and crashes on every Etterna skin import unless the skin already exists.

This happens due to `existing_folder.Value`. Even though the `WithConditional` container is not supposed to be rendered when the condition is false, its arguments are still being evaluated, which leads to a crash if `existing_folder` is None.