### PR TITLE
Fix osu beatmap rate detection 

### DIFF
--- a/prelude/src/Data/Library/Imports/Shared.fs
+++ b/prelude/src/Data/Library/Imports/Shared.fs
@@ -67,9 +67,10 @@ module Shared =
                             | Ok { Chart = original; Header = header } ->
                                 let original_duration = original.LastNote - original.FirstNote
                                 let incoming_duration = import.Chart.LastNote - import.Chart.FirstNote
+                                let relative_rate = original_duration / incoming_duration * 1.0f<rate>
                                 if
                                     original.Notes.Length = import.Chart.Notes.Length &&
-                                    abs (incoming_duration * float32 rate - original_duration) < 5.0f<ms>
+                                    abs (rate - relative_rate) < 0.025f<rate>
                                 then
                                     match import.Header.Origins |> Set.toSeq |> Seq.tryHead with
                                     | Some (ChartOrigin.Osu osu) ->

--- a/prelude/tests/Imports/RateDetection.fs
+++ b/prelude/tests/Imports/RateDetection.fs
@@ -1,0 +1,111 @@
+namespace Prelude.Tests.Imports
+
+open NUnit.Framework
+open Percyqaz.Common
+open Prelude.Data.Library.Imports
+
+
+module RateDetection =
+
+    [<Test>]
+    let RateDetection_BaseRate () =
+
+        let result = detect_rate_mod "[4K] Test [1.0x]"
+        let expected_value = None
+        
+        Assert.AreEqual(expected_value, result)
+
+    let RateDetection_BaseRate_DoubleDecimal () =
+
+        let result = detect_rate_mod "[4K] Test [1.00x]"
+        let expected_value = None
+        
+        Assert.AreEqual(expected_value, result)
+    
+    [<Test>]
+    let RateDetection_BaseRate_NoRate () =
+
+        let result = detect_rate_mod "[4K] Test"
+        let expected_value = None
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_SingleDecimalRate () =
+
+        let result = detect_rate_mod "[4K] Test [1.1x]"
+        let expected_value = Some 1.1f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_DoubleDecimalRate () =
+
+        let result = detect_rate_mod "[4K] Test [0.95x]"
+        let expected_value = Some 0.95f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_HighRate () =
+
+        let result = detect_rate_mod "[4K] Test [2.2x]"
+        let expected_value = Some 2.2f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_Parenthesis () =
+
+        let result = detect_rate_mod "[4K] Test (1.05x)"
+        let expected_value = Some 1.05f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_BpmOnly () =
+
+        let result = detect_rate_mod "[4K] Test [235bpm]"
+        let expected_value = None
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_BpmAfterRate () =
+
+        let result = detect_rate_mod "[4K] Test [1.05x] [235bpm]"
+        let expected_value = Some 1.05f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_BpmBeforeRate () =
+
+        let result = detect_rate_mod "[4K] Test [235bpm] (1.05x)"
+        let expected_value = Some 1.05f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_RateBeforeDiffName () =
+
+        let result = detect_rate_mod "[4K] [1.05x] Test"
+        let expected_value = Some 1.05f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_NoSpaces () =
+
+        let result = detect_rate_mod "[4K]Test[1.05x]"
+        let expected_value = Some 1.05f<rate>
+        
+        Assert.AreEqual(expected_value, result)
+
+    [<Test>]
+    let RateDetection_JunkDiffName () =
+
+        let result = detect_rate_mod "sdsfsdf 1.05 sdfsdfsdf"
+        let expected_value = Some 1.05f<rate>
+        
+        Assert.AreEqual(expected_value, result)

--- a/prelude/tests/Prelude.Tests.fsproj
+++ b/prelude/tests/Prelude.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net9.0</TargetFramework>
@@ -8,7 +8,7 @@
 	  <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup><Compile Include="Imports/RateDetection.fs" />
     <None Include="Data\Camellia - Backbeat Maniac (Evening) [Rewind VIP].osu">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Since some maps have their rates rounded (for example, an actual rate would often be something like 1.0533308677994424 instead of the displayed 1.05), those difficulties are still being downloaded due to the tolerance being too low.

I increased the tolerance and made it depend on the beatmap length so only the base rate is downloaded.