### PR TITLE
Add Fantomas formatting checks to CI

### DIFF
--- a/.fantomasignore
+++ b/.fantomasignore
@@ -1,0 +1,9 @@
+interlude
+engine
+libraries
+prelude/src
+prelude/playground
+prelude/tests/*
+!prelude/tests/Helpers
+tools
+online

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -3,8 +3,9 @@ name: Continuous integration
 on:
   push:
     branches: [ "main" ]
+    
 jobs:
-  automated-tests:
+  main-ci-checks:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,13 +1,8 @@
 name: Continuous integration
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
-    
-permissions:
-  contents: write
-  pull-requests: write
-    
 jobs:
   automated-tests:
 
@@ -35,9 +30,10 @@ jobs:
     - name: Run formatting checks
       run: fantomas --check .
         
-    - name: Approve PRs from Percyqaz if checks pass
-      if: ${{ github.actor == 'percyqaz' }}
-      run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Notify of failure in main
+      if: failure() && github.repository == 'YAVSRG/YAVSRG'
+      uses: tsickert/discord-webhook@v5.3.0
+      with:
+        webhook-url: ${{ secrets.DEV_WEBHOOK_URL }}
+        content: |
+          <@165506274820096000> CI checks did not pass in main. Skill issue exists between chair and keyboard

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: write
     
 jobs:
-  automated-tests:
-
+  pull-request-ci-checks:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Updates the code checks for main/prs to include running fantomas for formatting on the codebase
Currently configured to just format some test helpers in prelude, this will be incrementally changed to add formatting rule coverage for the codebase

Also includes a change where PRs from me will be approved if all these checks pass
I can't approve my own PRs so I currently have to override the branch protection rules to merge PRs
This change (if it works) means I make all changes through the same PR process as any other contributor