### PR TITLE
fix: consistent graph combo formatting

### DIFF
--- a/interlude/src/Features/Score/Graph.fs
+++ b/interlude/src/Features/Score/Graph.fs
@@ -180,7 +180,7 @@ and ScoreGraph(score_info: ScoreInfo, stats: ScoreScreenStats ref) =
 
         Text.fill_b (
             Style.font,
-            sprintf "%.4f%%, %ix" (info.Accuracy * 100.0) info.Combo,
+            sprintf "%.4f%%  •  %ix" (info.Accuracy * 100.0) info.Combo,
             text_b,
             text_color,
             Alignment.LEFT
@@ -263,7 +263,7 @@ and ScoreGraph(score_info: ScoreInfo, stats: ScoreScreenStats ref) =
 
         Text.fill_b (
             Style.font,
-            sprintf "%.4f%% %ix" (accuracy * 100.0) combo,
+            sprintf "%.4f%%  •  %ix" (accuracy * 100.0) combo,
             text_b,
             text_color,
             Alignment.LEFT

--- a/interlude/src/Features/Score/Graph.fs
+++ b/interlude/src/Features/Score/Graph.fs
@@ -175,8 +175,8 @@ and ScoreGraph(score_info: ScoreInfo, stats: ScoreScreenStats ref) =
         let text_color = if stats.Value.ColumnFilterApplied then Colors.text_green else Colors.text
         let judgement_count = Array.sum info.Judgements
 
-        let ma = sprintf "  •  MA: %s" (JudgementRatio.Format(info.Judgements, 0))
-        let pa = sprintf "  •  PA: %s" (JudgementRatio.Format(info.Judgements, 1))
+        let ma = JudgementRatio.Format(info.Judgements, 0)
+        let pa = JudgementRatio.Format(info.Judgements, 1)
 
         Text.fill_b (
             Style.font,
@@ -196,7 +196,7 @@ and ScoreGraph(score_info: ScoreInfo, stats: ScoreScreenStats ref) =
 
         Text.fill_b (
             Style.font,
-            sprintf "G: %i%s%s" info.GhostTaps ma pa,
+            sprintf "G: %i  •  MA: %s  •  PA: %s" info.GhostTaps ma pa,
             text_b.Translate(0.0f, row_height * 2.0f),
             text_color,
             Alignment.LEFT
@@ -258,8 +258,8 @@ and ScoreGraph(score_info: ScoreInfo, stats: ScoreScreenStats ref) =
             |> sqrt
         let ghost_taps = post.GhostTaps - pre.GhostTaps
 
-        let ma = sprintf "  •  MA: %s" (JudgementRatio.Format(judgement_diff, 0))
-        let pa = sprintf "  •  PA: %s" (JudgementRatio.Format(judgement_diff, 1))
+        let ma = JudgementRatio.Format(judgement_diff, 0)
+        let pa = JudgementRatio.Format(judgement_diff, 1)
 
         Text.fill_b (
             Style.font,
@@ -279,7 +279,7 @@ and ScoreGraph(score_info: ScoreInfo, stats: ScoreScreenStats ref) =
 
         Text.fill_b (
             Style.font,
-            sprintf "G: %i%s%s" ghost_taps ma pa,
+            sprintf "G: %i  •  MA: %s  •  PA: %s" ghost_taps ma pa,
             text_b.Translate(0.0f, row_height * 2.0f),
             text_color,
             Alignment.LEFT


### PR DESCRIPTION
also includes `style: clearer MA/PA score graph formatting`

<img width="330" height="341" alt="image" src="https://github.com/user-attachments/assets/bb79d20c-5d16-46dd-ace3-e1c6872fd590" />
