### PR TITLE
Update CI pipelines and fix build error

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         submodules: true
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
     

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Continuous integration (Main)
 
 on:
   push:

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -14,12 +14,12 @@ jobs:
     if: github.repository == 'YAVSRG/YAVSRG'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
     
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
           

--- a/.github/workflows/release-interlude-dry-run.yml
+++ b/.github/workflows/release-interlude-dry-run.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         submodules: true
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
         

--- a/.github/workflows/release-interlude.yml
+++ b/.github/workflows/release-interlude.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         submodules: true
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
         

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -6,12 +6,12 @@ jobs:
   test_server:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
     
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
           

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         submodules: true
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
     

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Continuous integration (Pull request)
 
 on:
   pull_request:

--- a/engine/src/Graphics/Batch.fs
+++ b/engine/src/Graphics/Batch.fs
@@ -59,7 +59,7 @@ type internal Batch =
 
         this.vcount <- this.vcount + 1
 
-    member inline this.Texture(t: Texture) : unit =
+    member this.Texture(t: Texture) : unit =
         if this.last_texture_handle <> t.Handle then
             this.Draw()
 


### PR DESCRIPTION
Fixes code that is failing in CI for whatever reason, despite having passed unchanged a couple of weeks ago and building on my machine

Also updated the names/versions of steps in the CI workflows to get rid of deprecation warnings while I'm at it