### PR TITLE
fix: distinct A color in wife3 ruleset

### DIFF
--- a/prelude/src/Gameplay/Rulesets/Wife3.fs
+++ b/prelude/src/Gameplay/Rulesets/Wife3.fs
@@ -77,17 +77,17 @@ module Wife3 =
                     {
                         Name = "A"
                         Accuracy = 0.8
-                        Color = Color.Lime
+                        Color = Color.IndianRed
                     }
                     {
                         Name = "A."
                         Accuracy = 0.85
-                        Color = Color.Lime
+                        Color = Color.IndianRed
                     }
                     {
                         Name = "A:"
                         Accuracy = 0.9
-                        Color = Color.Lime
+                        Color = Color.IndianRed
                     }
                     {
                         Name = "AA"


### PR DESCRIPTION
another color might be more suitable if indianred looks too similar to the red of D rank

<img width="459" height="120" alt="image" src="https://github.com/user-attachments/assets/7ffdb931-73fd-4788-b9a0-6a735f0a7094" />
