### PR TITLE
fix: blank session when advancing past latest session (crash fix)

### DIFF
--- a/prelude/src/Data/Stats/Stats.fs
+++ b/prelude/src/Data/Stats/Stats.fs
@@ -244,7 +244,7 @@ type Stats =
                 | Some sessions_on_day ->
                     Some(date, sessions_on_day.[0])
                 | None ->
-                    if date = TODAY then None else loop()
+                    if date >= TODAY then None else loop()
             loop()
                 
         find_session_later_today() |> Option.orElseWith find_next_day_with_sessions


### PR DESCRIPTION
[Screencast_20260903_185701.webm](https://github.com/user-attachments/assets/0301fc25-81be-44dd-8c59-900a5f15d8d5)
I don't expect this to be the last iteration of this fix before it's merged, I feel like there's a better way to prevent the crash